### PR TITLE
ci: build macOS arm64 binary

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -29,7 +29,7 @@ jobs:
           cache: true
       - name: Build wasmVision binary
         run: |
-          go build -tags static -o ./build/wasmvision ./cmd/wasmvision
+          go build -o ./build/wasmvision ./cmd/wasmvision
       - name: Archive wasmvision binary
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,0 +1,37 @@
+name: macOS
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: macos-14
+    steps:
+      - name: Install Dependencies
+        run: |
+          rm /usr/local/bin/2to3*
+          rm /usr/local/bin/idle3*
+          rm /usr/local/bin/pydoc*
+          rm /usr/local/bin/python3*
+          brew install opencv
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.23'
+          cache: true
+      - name: Build wasmVision binary
+        run: |
+          go build -tags static -o ./build/wasmvision ./cmd/wasmvision
+      - name: Archive wasmvision binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: wasmvision-macos-arm64
+          path: ./build/wasmvision

--- a/README.md
+++ b/README.md
@@ -80,3 +80,4 @@ The pipeline of Processor modules are called in order, one after another. The ou
 
 See the [ARCHITECTURE.md](ARCHITECTURE.md) document for more details.
 
+

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.23.0
 require (
 	github.com/orsinium-labs/wypes v0.1.4
 	github.com/tetratelabs/wazero v1.8.0
-	gocv.io/x/gocv v0.38.1-0.20240918183700-fa6336ebffd4
+	gocv.io/x/gocv v0.38.1-0.20240921163907-f21ab9a76667
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -14,5 +14,5 @@ github.com/urfave/cli/v2 v2.27.4 h1:o1owoI+02Eb+K107p27wEX9Bb8eqIoZCfLXloLUSWJ8=
 github.com/urfave/cli/v2 v2.27.4/go.mod h1:m4QzxcD2qpra4z7WhzEGn74WZLViBnMpb1ToCAKdGRQ=
 github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1 h1:gEOO8jv9F4OT7lGCjxCBTO/36wtF6j2nSip77qHd4x4=
 github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1/go.mod h1:Ohn+xnUBiLI6FVj/9LpzZWtj1/D6lUovWYBkxHVV3aM=
-gocv.io/x/gocv v0.38.1-0.20240918183700-fa6336ebffd4 h1:UiVqMrWSnv/6zdZgXk0wkt0dJTMf2rEW3m+Ii7H0NcI=
-gocv.io/x/gocv v0.38.1-0.20240918183700-fa6336ebffd4/go.mod h1:zYdWMj29WAEznM3Y8NsU3A0TRq/wR/cy75jeUypThqU=
+gocv.io/x/gocv v0.38.1-0.20240921163907-f21ab9a76667 h1:5XGW248HKzFpX3Aupn3ZJ5gMPBe71tkLf+CIgnhJL/0=
+gocv.io/x/gocv v0.38.1-0.20240921163907-f21ab9a76667/go.mod h1:zYdWMj29WAEznM3Y8NsU3A0TRq/wR/cy75jeUypThqU=


### PR DESCRIPTION
This PR builds a macOS binary for arm64 targets. It does require homebrew install of opencv, since  fullystatic linking of macOS binaries is seemingly not allowed.

See https://github.com/golang/go/issues/50669