### PR TITLE
cmd: add listall command

### DIFF
--- a/USING.md
+++ b/USING.md
@@ -124,3 +124,33 @@ wasmvision download processor candy
 ```shell
 wasmvision download model candy-9
 ```
+
+## `wasmvision listall`
+
+```shell
+NAME:
+   wasmvision listall - Lists all known models and processors
+
+USAGE:
+   wasmvision listall command [command options]
+
+COMMANDS:
+   models      lists all known computer vision models
+   processors  lists all known wasm processors
+   help, h     Shows a list of commands or help for one command
+
+OPTIONS:
+   --help, -h  show help
+```
+
+### Show a list of all models that can be downloaded, either manually or automatically.
+
+```shell
+wasmvision listall models
+```
+
+### Show a list of all processors that can be downloaded, either manually or automatically.
+
+```shell
+wasmvision listall processors
+```

--- a/cmd/wasmvision/listall.go
+++ b/cmd/wasmvision/listall.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/urfave/cli/v2"
+	"github.com/wasmvision/wasmvision/guest"
+	"github.com/wasmvision/wasmvision/models"
+)
+
+func listallModels(cCtx *cli.Context) error {
+	printModels()
+	fmt.Println()
+
+	return nil
+}
+
+func listallProcessors(cCtx *cli.Context) error {
+	printProcessors()
+	fmt.Println()
+
+	return nil
+}
+
+type keyValue struct {
+	key   string
+	value string
+}
+
+func printModels() {
+	s := make([]keyValue, 0, len(models.KnownModels))
+	for k, v := range models.KnownModels {
+		s = append(s, keyValue{k, v.Alias})
+	}
+
+	sort.SliceStable(s, func(i, j int) bool {
+		return s[i].value < s[j].value
+	})
+
+	// iterate over the slice to get the desired order
+	for _, v := range s {
+		fmt.Println(v.value)
+	}
+}
+
+func printProcessors() {
+	s := make([]keyValue, 0, len(guest.KnownProcessors))
+	for k, v := range guest.KnownProcessors {
+		s = append(s, keyValue{k, v.Alias})
+	}
+
+	sort.SliceStable(s, func(i, j int) bool {
+		return s[i].value < s[j].value
+	})
+
+	// iterate over the slice to get the desired order
+	for _, v := range s {
+		fmt.Println(v.value)
+	}
+}

--- a/cmd/wasmvision/main.go
+++ b/cmd/wasmvision/main.go
@@ -70,6 +70,22 @@ func main() {
 				Action: info,
 			},
 			{
+				Name:  "listall",
+				Usage: "Lists all known models and processors",
+				Subcommands: []*cli.Command{
+					{
+						Name:   "models",
+						Usage:  "lists all known computer vision models",
+						Action: listallModels,
+					},
+					{
+						Name:   "processors",
+						Usage:  "lists all known wasm processors",
+						Action: listallProcessors,
+					},
+				},
+			},
+			{
 				Name:   "version",
 				Usage:  "Show version",
 				Action: version,

--- a/guest/processors.go
+++ b/guest/processors.go
@@ -52,7 +52,7 @@ var KnownProcessors = map[string]ProcessorFile{
 		URL:      "https://github.com/wasmvision/wasmvision/raw/refs/heads/main/processors/hello.wasm",
 	},
 	"mosaic": {
-		Alias:    "mosaic.wasm",
+		Alias:    "mosaic",
 		Filename: "mosaic.wasm",
 		URL:      "https://github.com/wasmvision/wasmvision/raw/refs/heads/main/processors/mosaic.wasm",
 	},


### PR DESCRIPTION
This PR adds a `listall` command to make it easier to discover downloadable models and processors.