### PR TITLE
feature: add support for wasmvision:platform/config interface

### DIFF
--- a/cmd/wasmvision/main.go
+++ b/cmd/wasmvision/main.go
@@ -24,6 +24,11 @@ var (
 		&cli.BoolFlag{Name: "model-download", Aliases: []string{"download"}, Value: true, Usage: "automatically download known models (default: true)"},
 		&cli.StringFlag{Name: "processors-dir", Aliases: []string{"processors"}, EnvVars: []string{"WASMVISION_PROCESSORS_DIR"}, Usage: "directory for processor loading (default to $home/processors)"},
 		&cli.BoolFlag{Name: "processor-download", Value: true, Usage: "automatically download known processors (default: true)"},
+		&cli.StringSliceFlag{
+			Name:    "config",
+			Aliases: []string{"c"},
+			Usage:   "configuration for processors. Format: -config key1=val1 -config key2=val2",
+		},
 	}
 
 	downloadFlags = []cli.Flag{

--- a/cmd/wasmvision/run.go
+++ b/cmd/wasmvision/run.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strings"
 
 	"github.com/urfave/cli/v2"
 	"github.com/wasmvision/wasmvision/capture"
@@ -32,6 +33,16 @@ func run(cCtx *cli.Context) error {
 	}
 	logging := cCtx.Bool("logging")
 
+	settings := map[string]string{}
+	config := cCtx.StringSlice("config")
+	for _, c := range config {
+		parts := strings.Split(c, "=")
+		if len(parts) != 2 {
+			return fmt.Errorf("invalid config format: %v", c)
+		}
+		settings[parts[0]] = parts[1]
+	}
+
 	ctx := context.Background()
 
 	// load wasm runtime
@@ -39,6 +50,7 @@ func run(cCtx *cli.Context) error {
 		ProcessorsDir: processorsDir,
 		ModelsDir:     modelsDir,
 		Logging:       logging,
+		Settings:      settings,
 	})
 	defer r.Close(ctx)
 

--- a/config/store.go
+++ b/config/store.go
@@ -1,0 +1,30 @@
+package config
+
+// Store is a store for config info.
+type Store struct {
+	storeMap map[string]string
+}
+
+// NewStore creates a new Store.
+func NewStore() *Store {
+	return &Store{
+		storeMap: map[string]string{},
+	}
+}
+
+// Get returns a config value from the store.
+func (s *Store) Get(key string) (string, bool) {
+	val, ok := s.storeMap[key]
+	return val, ok
+}
+
+// Set sets a config value in the store.
+func (s *Store) Set(key, val string) error {
+	s.storeMap[key] = val
+	return nil
+}
+
+// Delete deletes a frame from the cache.
+func (s *Store) Delete(key string) {
+	delete(s.storeMap, key)
+}

--- a/config/store.go
+++ b/config/store.go
@@ -6,9 +6,9 @@ type Store struct {
 }
 
 // NewStore creates a new Store.
-func NewStore() *Store {
+func NewStore(s map[string]string) *Store {
 	return &Store{
-		storeMap: map[string]string{},
+		storeMap: s,
 	}
 }
 

--- a/cv/context.go
+++ b/cv/context.go
@@ -1,9 +1,12 @@
 package cv
 
+import "github.com/wasmvision/wasmvision/config"
+
 // Context is the configuration for the cv package used when each call is made
 // from the guest module.
 type Context struct {
 	ReturnDataPtr uint32
 	ModelsDir     string
 	Logging       bool
+	Config        *config.Store
 }

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/wasmvision/wasmvision
 
 go 1.22.0
 
+replace github.com/orsinium-labs/wypes => github.com/hybridgroup/wypes v0.0.0-20241012180508-d18933158d2b
+
 require (
 	github.com/orsinium-labs/wypes v0.2.0
 	github.com/tetratelabs/wazero v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -328,6 +328,8 @@ github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hybridgroup/mjpeg v0.0.0-20140228234708-4680f319790e h1:xCcwD5FOXul+j1dn8xD16nbrhJkkum/Cn+jTd/u1LhY=
 github.com/hybridgroup/mjpeg v0.0.0-20140228234708-4680f319790e/go.mod h1:eagM805MRKrioHYuU7iKLUyFPVKqVV6um5DAvCkUtXs=
+github.com/hybridgroup/wypes v0.0.0-20241012180508-d18933158d2b h1:8Yjb7uSm5OEgdsTytf+958OjIloY+B4ToquQrw2DKb8=
+github.com/hybridgroup/wypes v0.0.0-20241012180508-d18933158d2b/go.mod h1:FSNWGo8I6/D5RYXMkCxyu71TXJAlwJGQUxgs4i6MAwo=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
@@ -351,8 +353,6 @@ github.com/mitchellh/go-testing-interface v1.14.1 h1:jrgshOhYAUVNMAJiKbEu7EqAwgJ
 github.com/mitchellh/go-testing-interface v1.14.1/go.mod h1:gfgS7OtZj6MA4U1UrDRp04twqAjfvlZyCfX3sDjEym8=
 github.com/orsinium-labs/tinytest v1.0.0 h1:YiGm/whlGm3mn/ynx9CCFuvEa3Q6yEGrzrKXEqJOkdc=
 github.com/orsinium-labs/tinytest v1.0.0/go.mod h1:GwcYBp0aKi6zujzBXFpCnqw6RSLSp9JSedDyu/V1DF4=
-github.com/orsinium-labs/wypes v0.2.0 h1:wyCoOT6BJgK5bzUyJ9244ONrEVY80ppVv6m63VdiI4U=
-github.com/orsinium-labs/wypes v0.2.0/go.mod h1:FSNWGo8I6/D5RYXMkCxyu71TXJAlwJGQUxgs4i6MAwo=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/runtime/host.go
+++ b/runtime/host.go
@@ -30,6 +30,7 @@ type InterpreterConfig struct {
 	ProcessorsDir string
 	ModelsDir     string
 	Logging       bool
+	Settings      map[string]string
 }
 
 // New creates a new Interpreter.
@@ -37,10 +38,7 @@ func New(ctx context.Context, conf InterpreterConfig) Interpreter {
 	r := wazero.NewRuntime(ctx)
 	wasi_snapshot_preview1.MustInstantiate(ctx, r)
 
-	configStore := config.NewStore()
-
-	// TODO: populate configStore from config file
-	configStore.Set("default", "value")
+	configStore := config.NewStore(conf.Settings)
 
 	cctx := cv.Context{
 		ModelsDir: conf.ModelsDir,

--- a/runtime/hostfuncs.go
+++ b/runtime/hostfuncs.go
@@ -13,6 +13,9 @@ func hostedModules(ctx *cv.Context) wypes.Modules {
 			"println": wypes.H1(hostPrintln),
 			"log":     wypes.H1(hostLogFunc(ctx)),
 		},
+		"wasmvision:platform/config": wypes.Module{
+			"get-config": wypes.H3(hostGetConfig(ctx)),
+		},
 	}
 }
 
@@ -26,6 +29,31 @@ func hostLogFunc(ctx *cv.Context) func(wypes.String) wypes.Void {
 		if ctx.Logging {
 			log.Println(msg.Unwrap())
 		}
+		return wypes.Void{}
+	}
+}
+
+func hostGetConfig(ctx *cv.Context) func(*wypes.Store, wypes.String, wypes.Result[wypes.String, wypes.String, wypes.UInt32]) wypes.Void {
+	return func(s *wypes.Store, key wypes.String, result wypes.Result[wypes.String, wypes.String, wypes.UInt32]) wypes.Void {
+		if s.Error != nil {
+			log.Printf("error in store after lift: %v\n", s.Error)
+		}
+		val, ok := ctx.Config.Get(key.Unwrap())
+		if !ok {
+			result.IsError = true
+			result.Error = wypes.UInt32(1) // no-such-key
+		} else {
+			result.IsError = false
+			result.OK = wypes.String{Raw: val}
+		}
+
+		result.DataPtr = ctx.ReturnDataPtr
+		result.Lower(s)
+
+		if s.Error != nil {
+			log.Printf("error in store after lower: %v\n", s.Error)
+		}
+
 		return wypes.Void{}
 	}
 }


### PR DESCRIPTION
This PR adds support for the `wasmvision:platform/config` interface.

It includes the ability to initialize the config when running wasmvision by using the `-config` flag.
