### PR TITLE
feature: implement wasmvision:platform/http host interface

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,11 +2,11 @@ module github.com/wasmvision/wasmvision
 
 go 1.22.0
 
-replace github.com/orsinium-labs/wypes => github.com/hybridgroup/wypes v0.0.0-20241012180508-d18933158d2b
+replace github.com/orsinium-labs/wypes => github.com/hybridgroup/wypes v0.0.0-20241014173510-50b43aa5accc
 
 require (
 	github.com/orsinium-labs/wypes v0.2.0
-	github.com/tetratelabs/wazero v1.8.0
+	github.com/tetratelabs/wazero v1.8.1
 	gocv.io/x/gocv v0.38.1-0.20241005133257-f4509078d485
 )
 

--- a/go.sum
+++ b/go.sum
@@ -328,8 +328,8 @@ github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hybridgroup/mjpeg v0.0.0-20140228234708-4680f319790e h1:xCcwD5FOXul+j1dn8xD16nbrhJkkum/Cn+jTd/u1LhY=
 github.com/hybridgroup/mjpeg v0.0.0-20140228234708-4680f319790e/go.mod h1:eagM805MRKrioHYuU7iKLUyFPVKqVV6um5DAvCkUtXs=
-github.com/hybridgroup/wypes v0.0.0-20241012180508-d18933158d2b h1:8Yjb7uSm5OEgdsTytf+958OjIloY+B4ToquQrw2DKb8=
-github.com/hybridgroup/wypes v0.0.0-20241012180508-d18933158d2b/go.mod h1:FSNWGo8I6/D5RYXMkCxyu71TXJAlwJGQUxgs4i6MAwo=
+github.com/hybridgroup/wypes v0.0.0-20241014173510-50b43aa5accc h1:vtmc0jb25D+H5QK5Je7cfcQRFznJBJuxufnDVlALgSY=
+github.com/hybridgroup/wypes v0.0.0-20241014173510-50b43aa5accc/go.mod h1:FSNWGo8I6/D5RYXMkCxyu71TXJAlwJGQUxgs4i6MAwo=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
@@ -367,8 +367,8 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/tetratelabs/wazero v1.8.0 h1:iEKu0d4c2Pd+QSRieYbnQC9yiFlMS9D+Jr0LsRmcF4g=
-github.com/tetratelabs/wazero v1.8.0/go.mod h1:yAI0XTsMBhREkM/YDAK/zNou3GoiAce1P6+rp/wQhjs=
+github.com/tetratelabs/wazero v1.8.1 h1:NrcgVbWfkWvVc4UtT4LRLDf91PsOzDzefMdwhLfA550=
+github.com/tetratelabs/wazero v1.8.1/go.mod h1:yAI0XTsMBhREkM/YDAK/zNou3GoiAce1P6+rp/wQhjs=
 github.com/ulikunitz/xz v0.5.10 h1:t92gobL9l3HE202wg3rlk19F6X+JOxl9BBrCCMYEYd8=
 github.com/ulikunitz/xz v0.5.10/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
 github.com/urfave/cli/v2 v2.27.4 h1:o1owoI+02Eb+K107p27wEX9Bb8eqIoZCfLXloLUSWJ8=

--- a/guest/module.go
+++ b/guest/module.go
@@ -17,7 +17,7 @@ func NewModule(ctx context.Context, m api.Module) Module {
 	var returnDataPtr uint32
 	malloc := m.ExportedFunction("malloc")
 	if malloc != nil {
-		res, err := malloc.Call(ctx, 1024)
+		res, err := malloc.Call(ctx, 2048)
 		if err == nil {
 			returnDataPtr = uint32(res[0])
 		}

--- a/runtime/host.go
+++ b/runtime/host.go
@@ -116,7 +116,7 @@ func (intp *Interpreter) Processors() []guest.Module {
 
 // RegisterGuestModule registers a guest module with the interpreter.
 func (intp *Interpreter) RegisterGuestModule(ctx context.Context, name string, module []byte) error {
-	mod, err := intp.r.InstantiateWithConfig(ctx, module, wazero.NewModuleConfig().WithName(name).WithStartFunctions("_initialize"))
+	mod, err := intp.r.InstantiateWithConfig(ctx, module, wazero.NewModuleConfig().WithName(name).WithStartFunctions("_initialize", "_start"))
 	if err != nil {
 		return err
 	}

--- a/runtime/hostfuncs.go
+++ b/runtime/hostfuncs.go
@@ -2,14 +2,18 @@ package runtime
 
 import (
 	"bytes"
+	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"io"
 	"log"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/orsinium-labs/wypes"
 	"github.com/wasmvision/wasmvision/cv"
+	"gocv.io/x/gocv"
 )
 
 func hostedModules(ctx *cv.Context) wypes.Modules {
@@ -18,8 +22,9 @@ func hostedModules(ctx *cv.Context) wypes.Modules {
 			"get-config": wypes.H3(hostGetConfigFunc(ctx)),
 		},
 		"wasmvision:platform/http": wypes.Module{
-			"get":  wypes.H3(httpGetFunc(ctx)),
-			"post": wypes.H5(httpPostFunc(ctx)),
+			"get":        wypes.H3(httpGetFunc(ctx)),
+			"post":       wypes.H5(httpPostFunc(ctx)),
+			"post-image": wypes.H7(httpPostImageFunc(ctx)),
 		},
 		"wasmvision:platform/logging": wypes.Module{
 			"println": wypes.H1(hostPrintln),
@@ -145,7 +150,70 @@ func httpPostFunc(ctx *cv.Context) func(*wypes.Store, wypes.String, wypes.String
 
 		result.Lower(s)
 		if s.Error != nil {
-			log.Printf("httpGetFunc error in store after lower: %v\n", s.Error)
+			log.Printf("httpPostFunc error in store after lower: %v\n", s.Error)
+		}
+
+		return wypes.Void{}
+	}
+}
+
+func httpPostImageFunc(ctx *cv.Context) func(*wypes.Store, wypes.String, wypes.String, wypes.Bytes, wypes.String, wypes.HostRef[*cv.Frame], wypes.Result[wypes.Bytes, wypes.Bytes, wypes.UInt32]) wypes.Void {
+	return func(s *wypes.Store, url wypes.String, contentType wypes.String, template wypes.Bytes, responseKey wypes.String, mat wypes.HostRef[*cv.Frame], result wypes.Result[wypes.Bytes, wypes.Bytes, wypes.UInt32]) wypes.Void {
+		if ctx.Logging {
+			log.Println("http post image:", url.Unwrap())
+		}
+
+		// TODO: support other content types
+		ct := "application/json"
+
+		buffer, err := gocv.IMEncode(gocv.JPEGFileExt, mat.Raw.Image)
+		if err != nil {
+			log.Printf("error encoding image: %v\n", err)
+			result.IsError = true
+			result.Error = wypes.UInt32(3) // HTTPErrorRequestError
+			return wypes.Void{}
+		}
+
+		sEnc := base64.StdEncoding.EncodeToString(buffer.GetBytes())
+
+		tmpl := string(template.Raw)
+		tmpl = strings.Replace(tmpl, "%IMAGE%", sEnc, -1)
+
+		reqBody := bytes.NewBuffer([]byte(tmpl))
+
+		resp, err := http.Post(url.Unwrap(), ct, reqBody)
+		if err != nil {
+			log.Printf("error posting image: %v\n", err)
+			result.IsError = true
+			result.Error = wypes.UInt32(3) // HTTPErrorRequestError
+			return wypes.Void{}
+		}
+
+		defer resp.Body.Close()
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			result.IsError = true
+			result.Error = wypes.UInt32(3) // HTTPErrorRequestError
+			return wypes.Void{}
+		}
+
+		var payload interface{}
+		if err := json.Unmarshal(body, &payload); err != nil {
+			result.IsError = true
+			result.Error = wypes.UInt32(3) // HTTPErrorRequestError
+			return wypes.Void{}
+		}
+		m := payload.(map[string]interface{})
+
+		val := m[responseKey.Unwrap()].(string)
+
+		result.IsError = false
+		result.OK = wypes.Bytes{Raw: []byte(val)}
+		result.DataPtr = ctx.ReturnDataPtr
+
+		result.Lower(s)
+		if s.Error != nil {
+			log.Printf("httpPostImageFunc error in store after lower: %v\n", s.Error)
 		}
 
 		return wypes.Void{}

--- a/runtime/hostfuncs.go
+++ b/runtime/hostfuncs.go
@@ -1,7 +1,12 @@
 package runtime
 
 import (
+	"bytes"
+	"fmt"
+	"io"
 	"log"
+	"net/http"
+	"time"
 
 	"github.com/orsinium-labs/wypes"
 	"github.com/wasmvision/wasmvision/cv"
@@ -9,18 +14,25 @@ import (
 
 func hostedModules(ctx *cv.Context) wypes.Modules {
 	return wypes.Modules{
+		"wasmvision:platform/config": wypes.Module{
+			"get-config": wypes.H3(hostGetConfigFunc(ctx)),
+		},
+		"wasmvision:platform/http": wypes.Module{
+			"get":  wypes.H3(httpGetFunc(ctx)),
+			"post": wypes.H5(httpPostFunc(ctx)),
+		},
 		"wasmvision:platform/logging": wypes.Module{
 			"println": wypes.H1(hostPrintln),
 			"log":     wypes.H1(hostLogFunc(ctx)),
 		},
-		"wasmvision:platform/config": wypes.Module{
-			"get-config": wypes.H3(hostGetConfig(ctx)),
+		"wasmvision:platform/time": wypes.Module{
+			"now": wypes.H2(hostTimeNowFunc(ctx)),
 		},
 	}
 }
 
 func hostPrintln(msg wypes.String) wypes.Void {
-	println(msg.Unwrap())
+	fmt.Println(msg.Unwrap())
 	return wypes.Void{}
 }
 
@@ -33,7 +45,7 @@ func hostLogFunc(ctx *cv.Context) func(wypes.String) wypes.Void {
 	}
 }
 
-func hostGetConfig(ctx *cv.Context) func(*wypes.Store, wypes.String, wypes.Result[wypes.String, wypes.String, wypes.UInt32]) wypes.Void {
+func hostGetConfigFunc(ctx *cv.Context) func(*wypes.Store, wypes.String, wypes.Result[wypes.String, wypes.String, wypes.UInt32]) wypes.Void {
 	return func(s *wypes.Store, key wypes.String, result wypes.Result[wypes.String, wypes.String, wypes.UInt32]) wypes.Void {
 		if s.Error != nil {
 			log.Printf("error in store after lift: %v\n", s.Error)
@@ -55,5 +67,95 @@ func hostGetConfig(ctx *cv.Context) func(*wypes.Store, wypes.String, wypes.Resul
 		}
 
 		return wypes.Void{}
+	}
+}
+
+func httpGetFunc(ctx *cv.Context) func(*wypes.Store, wypes.String, wypes.Result[wypes.Bytes, wypes.Bytes, wypes.UInt32]) wypes.Void {
+	return func(s *wypes.Store, url wypes.String, result wypes.Result[wypes.Bytes, wypes.Bytes, wypes.UInt32]) wypes.Void {
+		if ctx.Logging {
+			log.Println("http get:", url.Unwrap())
+		}
+
+		resp, err := http.Get(url.Unwrap())
+		if err != nil {
+			result.IsError = true
+			result.Error = wypes.UInt32(3) // HTTPErrorRequestError
+			return wypes.Void{}
+		}
+
+		defer resp.Body.Close()
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			result.IsError = true
+			result.Error = wypes.UInt32(3) // HTTPErrorRequestError
+			return wypes.Void{}
+		}
+
+		// HACK: limit the size of the response to 128 bytes, for now.
+		max := 128
+		if len(body) < max {
+			max = len(body)
+		}
+
+		result.IsError = false
+		result.OK = wypes.Bytes{Raw: body[:max]}
+		result.DataPtr = ctx.ReturnDataPtr
+
+		result.Lower(s)
+		if s.Error != nil {
+			log.Printf("httpGetFunc error in store after lower: %v\n", s.Error)
+		}
+
+		return wypes.Void{}
+	}
+}
+
+func httpPostFunc(ctx *cv.Context) func(*wypes.Store, wypes.String, wypes.String, wypes.Bytes, wypes.Result[wypes.Bytes, wypes.Bytes, wypes.UInt32]) wypes.Void {
+	return func(s *wypes.Store, url wypes.String, contentType wypes.String, request wypes.Bytes, result wypes.Result[wypes.Bytes, wypes.Bytes, wypes.UInt32]) wypes.Void {
+		if ctx.Logging {
+			log.Println("http post:", url.Unwrap())
+		}
+
+		reqBody := bytes.NewBuffer(request.Raw)
+
+		resp, err := http.Post(url.Unwrap(), contentType.Unwrap(), reqBody)
+		if err != nil {
+			result.IsError = true
+			result.Error = wypes.UInt32(3) // HTTPErrorRequestError
+			return wypes.Void{}
+		}
+
+		defer resp.Body.Close()
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			result.IsError = true
+			result.Error = wypes.UInt32(3) // HTTPErrorRequestError
+			return wypes.Void{}
+		}
+
+		// HACK: limit the size of the response to 128 bytes, for now.
+		max := 128
+		if len(body) < max {
+			max = len(body)
+		}
+
+		result.IsError = false
+		result.OK = wypes.Bytes{Raw: body[:max]}
+		result.DataPtr = ctx.ReturnDataPtr
+
+		result.Lower(s)
+		if s.Error != nil {
+			log.Printf("httpGetFunc error in store after lower: %v\n", s.Error)
+		}
+
+		return wypes.Void{}
+	}
+}
+
+func hostTimeNowFunc(ctx *cv.Context) func(*wypes.Store, wypes.UInt32) wypes.UInt64 {
+	return func(*wypes.Store, wypes.UInt32) wypes.UInt64 {
+		t := time.Now().UnixMicro()
+
+		return wypes.UInt64(t)
 	}
 }


### PR DESCRIPTION
This PR is to implement the `wasmvision:platform/http` host interface. Currently working, but some caveats. Biggest one of which is that it will currently only return max 128 bytes of response from the host.

Will have to deal with that in a future PR.