### PR TITLE
engine: correct race conditions and add more test coverage for mjpeg stream and video writer

### DIFF
--- a/engine/mjpeg.go
+++ b/engine/mjpeg.go
@@ -31,7 +31,7 @@ func NewMJPEGStream(refs *runtime.MapRefs, port string) *MJPEGStream {
 }
 
 // Start starts the MJPEG stream server.
-func (s *MJPEGStream) Start() {
+func (s *MJPEGStream) Start() error {
 	s.stream = mjpeg.NewStream()
 
 	http.Handle("/", s.stream)
@@ -42,8 +42,11 @@ func (s *MJPEGStream) Start() {
 	}
 
 	go s.publishFrames()
+	go func() {
+		log.Println(s.server.ListenAndServe())
+	}()
 
-	log.Fatal(s.server.ListenAndServe())
+	return nil
 }
 
 // Close closes the MJPEG stream.

--- a/engine/mjpeg_test.go
+++ b/engine/mjpeg_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/wasmvision/wasmvision/cv"
 	"github.com/wasmvision/wasmvision/runtime"
+	"gocv.io/x/gocv"
 )
 
 func TestMJPEGStream(t *testing.T) {
@@ -35,12 +36,10 @@ func TestMJPEGStreamStart(t *testing.T) {
 
 		s := NewMJPEGStream(refs, port)
 
+		s.Start()
 		defer s.Close()
-
-		go s.Start()
-
-		frm := cv.NewEmptyFrame()
-
+		img := gocv.IMRead("../images/wasmvision-logo.png", gocv.IMReadColor)
+		frm := cv.NewFrame(img)
 		if err := s.Publish(frm); err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}

--- a/engine/videowriter.go
+++ b/engine/videowriter.go
@@ -59,9 +59,9 @@ func (vw *VideoWriter) Start(source capture.Capture) error {
 		return err
 	}
 
-	go vw.writeFrames()
-
 	vw.writer = videoWriter
+
+	go vw.writeFrames()
 
 	return nil
 }

--- a/engine/videowriter_test.go
+++ b/engine/videowriter_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/wasmvision/wasmvision/cv"
 	"github.com/wasmvision/wasmvision/runtime"
+	"gocv.io/x/gocv"
 )
 
 func TestVideoWriter(t *testing.T) {
@@ -45,7 +46,8 @@ func TestVideoWriter(t *testing.T) {
 
 		defer vw.Close()
 
-		frm := cv.NewEmptyFrame()
+		img := gocv.IMRead("../images/wasmvision-logo.png", gocv.IMReadColor)
+		frm := cv.NewFrame(img)
 
 		if err := vw.Write(frm); err != nil {
 			t.Errorf("unexpected error: %v", err)


### PR DESCRIPTION
This PR corrects a couple of race conditions and adds more test coverage for mjpeg stream and video writer.