### PR TITLE
fix: correct usage for mjpeg streaming start

### DIFF
--- a/cmd/wasmvision/run.go
+++ b/cmd/wasmvision/run.go
@@ -78,7 +78,10 @@ func run(cCtx *cli.Context) error {
 		}
 		mjpegstream = engine.NewMJPEGStream(r.Refs, dest)
 
-		go mjpegstream.Start()
+		if err := mjpegstream.Start(); err != nil {
+			return fmt.Errorf("failed starting mjpeg stream: %w", err)
+		}
+
 		defer mjpegstream.Close()
 
 	case "file":


### PR DESCRIPTION
This PR corrects usage for mjpeg streaming `Start()` to check for errors, even though none will be returned at the moment.