### PR TITLE
feature: add gstreamer capture device and -capture flag to choose capture source type

### DIFF
--- a/capture/capture.go
+++ b/capture/capture.go
@@ -6,6 +6,8 @@ import (
 	"github.com/wasmvision/wasmvision/cv"
 )
 
+const defaultRetries = 3
+
 var ErrClosed = errors.New("capture device closed")
 
 // Capture is the interface that wraps the basic methods for capturing frames.

--- a/capture/gstreamer.go
+++ b/capture/gstreamer.go
@@ -1,0 +1,54 @@
+package capture
+
+import (
+	"github.com/wasmvision/wasmvision/cv"
+
+	"gocv.io/x/gocv"
+)
+
+type GStreamer struct {
+	device  string
+	stream  *gocv.VideoCapture
+	retries int
+}
+
+func NewGStreamer(device string) *GStreamer {
+	return &GStreamer{
+		device:  device,
+		retries: defaultRetries,
+	}
+}
+
+func (g *GStreamer) Open() error {
+	stream, err := gocv.OpenVideoCaptureWithAPI(g.device, gocv.VideoCaptureGstreamer)
+	if err != nil {
+		return err
+	}
+
+	g.stream = stream
+	return nil
+}
+
+func (g *GStreamer) Close() error {
+	return g.stream.Close()
+}
+
+func (g *GStreamer) Read() (*cv.Frame, error) {
+	img := gocv.NewMat()
+	if ok := g.stream.Read(&img); !ok {
+		g.retries--
+		if g.retries == 0 {
+			return &cv.Frame{}, ErrClosed
+		}
+
+		frame := cv.NewEmptyFrame()
+
+		return frame, nil
+	}
+
+	g.retries = defaultRetries
+
+	frame := cv.NewFrame(img)
+
+	return frame, nil
+}

--- a/capture/webcam.go
+++ b/capture/webcam.go
@@ -6,8 +6,6 @@ import (
 	"gocv.io/x/gocv"
 )
 
-const defaultRetries = 3
-
 type Webcam struct {
 	device  string
 	webcam  *gocv.VideoCapture

--- a/cmd/wasmvision/main.go
+++ b/cmd/wasmvision/main.go
@@ -11,7 +11,8 @@ import (
 
 var (
 	runFlags = []cli.Flag{
-		&cli.StringFlag{Name: "source", Aliases: []string{"s"}, Value: "0", Usage: "video capture source to use such as webcam or file (0 is the default webcam on most systems)"},
+		&cli.StringFlag{Name: "source", Aliases: []string{"s"}, Value: "0", Usage: "video capture source to use. webcam id, file name, or stream (0 is the default webcam on most systems)"},
+		&cli.StringFlag{Name: "capture", Value: "auto", Usage: "video capture source type to use (auto, webcam, gstreamer)"},
 		&cli.StringFlag{Name: "output", Aliases: []string{"o"}, Value: "mjpeg", Usage: "output type (mjpeg, file)"},
 		&cli.StringFlag{Name: "destination", Aliases: []string{"d"}, Usage: "output destination (port, file path)"},
 		&cli.StringSliceFlag{


### PR DESCRIPTION
This PR adds a `gstreamer` capture device and associated `-capture` flag to choose capture source type.

Currently only works on a local install of OpenCV on Linux. Adding gstreamer itself to the static builds will have to wait for a series of future PRs.