### PR TITLE
feature: use Alpine Linux images

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -31,19 +31,19 @@ The wasmVision engine. Includes some platform capabilities such as MJPEG streami
 
 ### Capture
 
-This is how wasmVision can capture or import images or video to be processed.
+This is how wasmVision can capture or import images or video to be processed from a connected webcam, from files, or from streams.
 
 ### Devices
 
-Specific hardware or software devices that capture images or video. Currently supported devices are a connected camera or a file input.
+Specific hardware or software devices that capture images or video. Currently supported devices are a connected camera, a file input, or a stream input using GStreamer.
 
 ### Runtime
 
-The wasmVision runtime consists of the WebAssembly runtime engine (currently Wazero) and the wasmVision host platform API functions such as logging and configuration.
+The wasmVision runtime consists of the WebAssembly runtime engine (currently Wazero) and the wasmVision host platform API functions such as logging, configuration, and making http calls to external servers.
 
 ### Processors
 
-The wasmCV image processing modules that are used by wasmVision. See [processors directory](./processors/).
+The image processing modules that are used by wasmVision. These are modules written using Go, Rust, or C, and compiled into WebAssembly. They use the [wasmCV interface](https://github.com/wasmvision/wasmcv) and the [wasmVision platform interface](https://github.com/wasmvision/wasmvision-sdk). See [processors directory](./processors/) for several processors you can use, or use as examples.
 
 ### OpenCV
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -2,7 +2,9 @@
 
 Do you want to try out the latest development builds, or work on developing wasmVision itself? If so, this is the place for information.
 
-However, if what you want to do is develop a wasmVision processing module, please see the [PROCESSOR.md document](./PROCESSOR.md).
+Do you want to develop a wasmVision processing module using WebAssembly? See the [PROCESSOR.md document](./PROCESSOR.md).
+
+Otherwise, read on!
 
 ## Latest builds
 
@@ -46,6 +48,8 @@ Run your desired docker commands using the tagged image `ghcr.io/wasmvision/wasm
 
 ## Local development
 
+### Linux
+
 If you have a local installation of both Go and OpenCV you can install wasmVision directly:
 
 ```shell
@@ -57,8 +61,34 @@ go install ./cmd/wasmvision/
 And run it:
 
 ```shell
-wasmvision run -p ./processors/hello.wasm -mjpeg=true
+wasmvision run -p ./processors/hello.wasm
+```
 
+### macOS
+
+You need to install Go and also OpenCV to build and run wasmVision locally.
+
+To install OpenCV using Homebrew:
+
+```shell
+brew install opencv
+```
+
+Now you can clone the repo and install it locally:
+
+```shell
+git clone https://github.com/wasmvision/wasmvision.git
+cd wasmvision
+go install ./cmd/wasmvision/
+```
+
+And run it:
+
+```shell
+wasmvision run -p ./processors/hello.wasm
+```
+
+### Docker
 
 You can run wasmVision using Docker.
 
@@ -66,4 +96,10 @@ Pull the current development version:
 
 ```shell
 docker pull ghcr.io/wasmvision/wasmvision:main
+```
+
+And run it:
+
+```shell
+docker run ghcr.io/wasmvision/wasmvision:main
 ```

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,21 +11,97 @@
 #   docker buildx build -t wasmvision:dev --platform=linux/amd64,linux/arm64 .
 #
 # first stage: build the wasmvision binary
-FROM --platform=$BUILDPLATFORM ghcr.io/hybridgroup/opencv:4.10.0-static AS wasmvision-build
+FROM --platform=linux/amd64 ghcr.io/hybridgroup/opencv:4.10.0-alpine AS opencv-amd64
+
+RUN apk update && apk add --no-cache \
+    build-base \
+    cmake \
+    git \
+    wget \
+    unzip \
+    pkgconfig \
+    glib-static \
+    gobject-introspection-dev
+
+# Install Go
+ARG GO_VERSION=1.23.2
+ARG TARGETARCH
+
+RUN wget https://golang.org/dl/go${GO_VERSION}.linux-${TARGETARCH}.tar.gz && \
+    tar -C /usr/local -xzf go${GO_VERSION}.linux-${TARGETARCH}.tar.gz && \
+    rm go${GO_VERSION}.linux-${TARGETARCH}.tar.gz
+
+ENV PATH="/usr/local/go/bin:${PATH}"
+ENV GOPATH=/go
 
 COPY . /src
-
 WORKDIR /src
+
+FROM --platform=linux/arm64 ghcr.io/hybridgroup/opencv:4.10.0-alpine AS opencv-arm64
+
+RUN apk update && apk add --no-cache \
+    build-base \
+    cmake \
+    git \
+    wget \
+    unzip \
+    pkgconfig \
+    glib-static \
+    gobject-introspection-dev
+
+# Install Go
+ARG GO_VERSION=1.23.2
+ARG TARGETARCH
+
+RUN wget https://golang.org/dl/go${GO_VERSION}.linux-${TARGETARCH}.tar.gz && \
+    tar -C /usr/local -xzf go${GO_VERSION}.linux-${TARGETARCH}.tar.gz && \
+    rm go${GO_VERSION}.linux-${TARGETARCH}.tar.gz
+
+ENV PATH="/usr/local/go/bin:${PATH}"
+ENV GOPATH=/go
+
+COPY . /src
+WORKDIR /src
+
+# second stage: build the wasmvision binary (linux/amd64)
+FROM --platform=linux/amd64 opencv-%{TARGETARCH} AS wasmvision-static-builder-amd64
+
+ENV CGO_CXXFLAGS="--std=c++11"
+ENV CGO_CPPFLAGS="-I/usr/local/include/opencv4"
+ENV CGO_LDFLAGS="-static -L/usr/local/lib -lopencv_gapi -lopencv_stitching -lopencv_alphamat -lopencv_aruco -lopencv_bgsegm -lopencv_bioinspired -lopencv_ccalib -lopencv_dnn_objdetect -lopencv_dnn_superres -lopencv_dpm -lopencv_face -lopencv_fuzzy -lopencv_hfs -lopencv_img_hash -lopencv_intensity_transform -lopencv_line_descriptor -lopencv_mcc -lopencv_quality -lopencv_rapid -lopencv_reg -lopencv_rgbd -lopencv_saliency -lopencv_signal -lopencv_stereo -lopencv_structured_light -lopencv_phase_unwrapping -lopencv_superres -lopencv_optflow -lopencv_surface_matching -lopencv_tracking -lopencv_highgui -lopencv_datasets -lopencv_text -lopencv_plot -lopencv_videostab -lopencv_videoio -lopencv_wechat_qrcode -lopencv_xfeatures2d -lopencv_shape -lopencv_ml -lopencv_ximgproc -lopencv_video -lopencv_xobjdetect -lopencv_objdetect -lopencv_calib3d -lopencv_imgcodecs -lopencv_features2d -lopencv_dnn -lopencv_flann -lopencv_xphoto -lopencv_photo -lopencv_imgproc -lopencv_core -L/usr/local/lib/opencv4/3rdparty -llibprotobuf -lade -littnotify -llibwebp -llibtiff -llibopenjp2 -lippiw -lippicv -llibjpeg-turbo -llibpng -L/lib -lzlib -lIlmImf -ldl -lm -lpthread -lrt -lavdevice -lm -latomic -lavfilter -pthread -lm -latomic -lswscale -lm -latomic -lpostproc -lm -latomic -lavformat -lm -latomic -lavcodec -lvpx -lx264 -lswresample -lm -latomic -lavutil -lbz2_static -llzma -lgstadaptivedemux-1.0 -lgstallocators-1.0 -lgstanalytics-1.0 -lgstapp-1.0 -lgstaudio-1.0 -lgstbadaudio-1.0 -lgstbase-1.0 -lgstbasecamerabinsrc-1.0 -lgstcodecparsers-1.0 -lgstcodecs-1.0 -lgstcontroller-1.0 -lgstcuda-1.0 -lgstfft-1.0 -lgstinsertbin-1.0 -lgstisoff-1.0 -lgstmpegts-1.0 -lgstmse-1.0 -lgstnet-1.0 -lgstpbutils-1.0 -lgstphotography-1.0 -lgstplay-1.0 -lgstplayer-1.0 -lgstreamer-1.0 -lgstriff-1.0 -lgstrtp-1.0 -lgstrtsp-1.0 -lgstsctp-1.0 -lgstsdp-1.0 -lgsttag-1.0 -lgsttranscoder-1.0 -lgsturidownloader-1.0 -lgstvideo-1.0 -lgstwebrtc-1.0 -lopenh264 -lstdc++ -lglib-2.0 -lgio-2.0 -lgmodule-2.0 -lgobject-2.0 -lgthread-2.0 -lgirepository-2.0 -lffi -lpcre2-8 -lintl"
 
 RUN --mount=target=. \
     --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg/mod \
-    go build -ldflags "-linkmode 'external' -extldflags '-static'" -tags netgo,osusergo,opencvstatic -o /build/wasmvision ./cmd/wasmvision
+    go build -ldflags "-linkmode 'external' -extldflags '-static'" -tags netgo,osusergo,customenv -o /build/wasmvision ./cmd/wasmvision
 
-# second stage: create a minimal image with the wasmvision binary
-FROM ubuntu:22.04 AS wasmvision-final
 
-COPY --from=wasmvision-build /build/wasmvision /run/wasmvision
+# second stage: build the wasmvision binary (linux/amd64)
+FROM --platform=linux/arm64 opencv-%{TARGETARCH} AS wasmvision-static-builder-arm64
+
+ENV CGO_CXXFLAGS="--std=c++11"
+ENV CGO_CPPFLAGS="-I/usr/local/include/opencv4"
+ENV CGO_LDFLAGS="-static -L/usr/local/lib -lopencv_gapi -lopencv_stitching -lopencv_alphamat -lopencv_aruco -lopencv_bgsegm -lopencv_bioinspired -lopencv_ccalib -lopencv_dnn_objdetect -lopencv_dnn_superres -lopencv_dpm -lopencv_face -lopencv_fuzzy -lopencv_hfs -lopencv_img_hash -lopencv_intensity_transform -lopencv_line_descriptor -lopencv_mcc -lopencv_quality -lopencv_rapid -lopencv_reg -lopencv_rgbd -lopencv_saliency -lopencv_signal -lopencv_stereo -lopencv_structured_light -lopencv_phase_unwrapping -lopencv_superres -lopencv_optflow -lopencv_surface_matching -lopencv_tracking -lopencv_highgui -lopencv_datasets -lopencv_text -lopencv_plot -lopencv_videostab -lopencv_videoio -lopencv_wechat_qrcode -lopencv_xfeatures2d -lopencv_shape -lopencv_ml -lopencv_ximgproc -lopencv_video -lopencv_xobjdetect -lopencv_objdetect -lopencv_calib3d -lopencv_imgcodecs -lopencv_features2d -lopencv_dnn -lopencv_flann -lopencv_xphoto -lopencv_photo -lopencv_imgproc -lopencv_core -L/usr/local/lib/opencv4/3rdparty -llibprotobuf -lade -littnotify -llibwebp -llibtiff -llibopenjp2 -llibjpeg-turbo -llibpng -L/lib -lzlib -lIlmImf -ldl -lm -lpthread -lrt -lavdevice -lm -latomic -lavfilter -pthread -lm -latomic -lswscale -lm -latomic -lpostproc -lm -latomic -lavformat -lm -latomic -lavcodec -lvpx -lx264 -lswresample -lm -latomic -lavutil -lbz2_static -llzma -lgstadaptivedemux-1.0 -lgstallocators-1.0 -lgstanalytics-1.0 -lgstapp-1.0 -lgstaudio-1.0 -lgstbadaudio-1.0 -lgstbase-1.0 -lgstbasecamerabinsrc-1.0 -lgstcodecparsers-1.0 -lgstcodecs-1.0 -lgstcontroller-1.0 -lgstcuda-1.0 -lgstfft-1.0 -lgstinsertbin-1.0 -lgstisoff-1.0 -lgstmpegts-1.0 -lgstmse-1.0 -lgstnet-1.0 -lgstpbutils-1.0 -lgstphotography-1.0 -lgstplay-1.0 -lgstplayer-1.0 -lgstreamer-1.0 -lgstriff-1.0 -lgstrtp-1.0 -lgstrtsp-1.0 -lgstsctp-1.0 -lgstsdp-1.0 -lgsttag-1.0 -lgsttranscoder-1.0 -lgsturidownloader-1.0 -lgstvideo-1.0 -lgstwebrtc-1.0 -lopenh264 -lstdc++ -lglib-2.0 -lgio-2.0 -lgmodule-2.0 -lgobject-2.0 -lgthread-2.0 -lgirepository-2.0 -lffi -lpcre2-8 -lintl -ltegra_hal"
+
+RUN --mount=target=. \
+    --mount=type=cache,target=/root/.cache/go-build \
+    --mount=type=cache,target=/go/pkg/mod \
+    go build -ldflags "-linkmode 'external' -extldflags '-static'" -tags netgo,osusergo,customenv -o /build/wasmvision ./cmd/wasmvision
+
+
+# final stage: create a minimal image with the wasmvision binary
+FROM --platform=linux/amd64 alpine:3.20 AS wasmvision-final-amd64
+
+COPY --from=wasmvision-build-${TARGETARCH} /build/wasmvision /run/wasmvision
+
+COPY ./processors/*.wasm /processors/
+
+ENTRYPOINT ["/run/wasmvision"]
+
+
+FROM --platform=linux/arm64 alpine:3.20 AS wasmvision-final-arm64
+
+COPY --from=wasmvision-build-${TARGETARCH} /build/wasmvision /run/wasmvision
 
 COPY ./processors/*.wasm /processors/
 

--- a/Dockerfile-builder
+++ b/Dockerfile-builder
@@ -2,8 +2,67 @@
 #
 # running:
 # docker run --rm -v $(pwd):/src -v $(pwd)/build/amd64/:/build -a stdout -a stderr --platform linux/amd64 ghcr.io/wasmvision/wasmvision-static-builder
-FROM ghcr.io/hybridgroup/opencv:4.10.0-static AS wasmvision-static-builder
+FROM --platform=linux/amd64 ghcr.io/hybridgroup/opencv:4.10.0-alpine AS opencv-amd64
+
+RUN apk update && apk add --no-cache \
+    build-base \
+    cmake \
+    git \
+    wget \
+    unzip \
+    pkgconfig \
+    glib-static \
+    gobject-introspection-dev
+
+# Install Go
+ARG GO_VERSION=1.23.2
+ARG TARGETARCH
+
+RUN wget https://golang.org/dl/go${GO_VERSION}.linux-${TARGETARCH}.tar.gz && \
+    tar -C /usr/local -xzf go${GO_VERSION}.linux-${TARGETARCH}.tar.gz && \
+    rm go${GO_VERSION}.linux-${TARGETARCH}.tar.gz
+
+ENV PATH="/usr/local/go/bin:${PATH}"
+ENV GOPATH=/go
 
 WORKDIR /src
 
-CMD go build -ldflags "-linkmode 'external' -extldflags '-static'" -tags netgo,osusergo,opencvstatic -o /build/wasmvision -buildvcs=false ./cmd/wasmvision
+ENV CGO_CXXFLAGS="--std=c++11"
+ENV CGO_CPPFLAGS="-I/usr/local/include/opencv4"
+ENV CGO_LDFLAGS="-static -L/usr/local/lib -lopencv_gapi -lopencv_stitching -lopencv_alphamat -lopencv_aruco -lopencv_bgsegm -lopencv_bioinspired -lopencv_ccalib -lopencv_dnn_objdetect -lopencv_dnn_superres -lopencv_dpm -lopencv_face -lopencv_fuzzy -lopencv_hfs -lopencv_img_hash -lopencv_intensity_transform -lopencv_line_descriptor -lopencv_mcc -lopencv_quality -lopencv_rapid -lopencv_reg -lopencv_rgbd -lopencv_saliency -lopencv_signal -lopencv_stereo -lopencv_structured_light -lopencv_phase_unwrapping -lopencv_superres -lopencv_optflow -lopencv_surface_matching -lopencv_tracking -lopencv_highgui -lopencv_datasets -lopencv_text -lopencv_plot -lopencv_videostab -lopencv_videoio -lopencv_wechat_qrcode -lopencv_xfeatures2d -lopencv_shape -lopencv_ml -lopencv_ximgproc -lopencv_video -lopencv_xobjdetect -lopencv_objdetect -lopencv_calib3d -lopencv_imgcodecs -lopencv_features2d -lopencv_dnn -lopencv_flann -lopencv_xphoto -lopencv_photo -lopencv_imgproc -lopencv_core -L/usr/local/lib/opencv4/3rdparty -llibprotobuf -lade -littnotify -llibwebp -llibtiff -llibopenjp2 -lippiw -lippicv -llibjpeg-turbo -llibpng -L/lib -lzlib -lIlmImf -ldl -lm -lpthread -lrt -lavdevice -lm -latomic -lavfilter -pthread -lm -latomic -lswscale -lm -latomic -lpostproc -lm -latomic -lavformat -lm -latomic -lavcodec -lvpx -lx264 -lswresample -lm -latomic -lavutil -lbz2_static -llzma -lgstadaptivedemux-1.0 -lgstallocators-1.0 -lgstanalytics-1.0 -lgstapp-1.0 -lgstaudio-1.0 -lgstbadaudio-1.0 -lgstbase-1.0 -lgstbasecamerabinsrc-1.0 -lgstcodecparsers-1.0 -lgstcodecs-1.0 -lgstcontroller-1.0 -lgstcuda-1.0 -lgstfft-1.0 -lgstinsertbin-1.0 -lgstisoff-1.0 -lgstmpegts-1.0 -lgstmse-1.0 -lgstnet-1.0 -lgstpbutils-1.0 -lgstphotography-1.0 -lgstplay-1.0 -lgstplayer-1.0 -lgstreamer-1.0 -lgstriff-1.0 -lgstrtp-1.0 -lgstrtsp-1.0 -lgstsctp-1.0 -lgstsdp-1.0 -lgsttag-1.0 -lgsttranscoder-1.0 -lgsturidownloader-1.0 -lgstvideo-1.0 -lgstwebrtc-1.0 -lopenh264 -lstdc++ -lglib-2.0 -lgio-2.0 -lgmodule-2.0 -lgobject-2.0 -lgthread-2.0 -lgirepository-2.0 -lffi -lpcre2-8 -lintl"
+
+CMD go build -ldflags "-linkmode 'external' -extldflags '-static'" -tags netgo,osusergo,customenv -o /build/wasmvision -buildvcs=false ./cmd/wasmvision
+
+
+FROM --platform=linux/arm64 ghcr.io/hybridgroup/opencv:4.10.0-alpine AS opencv-arm64
+
+RUN apk update && apk add --no-cache \
+    build-base \
+    cmake \
+    git \
+    wget \
+    unzip \
+    pkgconfig \
+    glib-static \
+    gobject-introspection-dev
+
+# Install Go
+ARG GO_VERSION=1.23.2
+ARG TARGETARCH
+
+RUN wget https://golang.org/dl/go${GO_VERSION}.linux-${TARGETARCH}.tar.gz && \
+    tar -C /usr/local -xzf go${GO_VERSION}.linux-${TARGETARCH}.tar.gz && \
+    rm go${GO_VERSION}.linux-${TARGETARCH}.tar.gz
+
+ENV PATH="/usr/local/go/bin:${PATH}"
+ENV GOPATH=/go
+
+WORKDIR /src
+
+ENV CGO_CXXFLAGS="--std=c++11"
+ENV CGO_CPPFLAGS="-I/usr/local/include/opencv4"
+ENV CGO_LDFLAGS="-static -L/usr/local/lib -lopencv_gapi -lopencv_stitching -lopencv_alphamat -lopencv_aruco -lopencv_bgsegm -lopencv_bioinspired -lopencv_ccalib -lopencv_dnn_objdetect -lopencv_dnn_superres -lopencv_dpm -lopencv_face -lopencv_fuzzy -lopencv_hfs -lopencv_img_hash -lopencv_intensity_transform -lopencv_line_descriptor -lopencv_mcc -lopencv_quality -lopencv_rapid -lopencv_reg -lopencv_rgbd -lopencv_saliency -lopencv_signal -lopencv_stereo -lopencv_structured_light -lopencv_phase_unwrapping -lopencv_superres -lopencv_optflow -lopencv_surface_matching -lopencv_tracking -lopencv_highgui -lopencv_datasets -lopencv_text -lopencv_plot -lopencv_videostab -lopencv_videoio -lopencv_wechat_qrcode -lopencv_xfeatures2d -lopencv_shape -lopencv_ml -lopencv_ximgproc -lopencv_video -lopencv_xobjdetect -lopencv_objdetect -lopencv_calib3d -lopencv_imgcodecs -lopencv_features2d -lopencv_dnn -lopencv_flann -lopencv_xphoto -lopencv_photo -lopencv_imgproc -lopencv_core -L/usr/local/lib/opencv4/3rdparty -llibprotobuf -lade -littnotify -llibwebp -llibtiff -llibopenjp2 -llibjpeg-turbo -llibpng -L/lib -lzlib -lIlmImf -ldl -lm -lpthread -lrt -lavdevice -lm -latomic -lavfilter -pthread -lm -latomic -lswscale -lm -latomic -lpostproc -lm -latomic -lavformat -lm -latomic -lavcodec -lvpx -lx264 -lswresample -lm -latomic -lavutil -lbz2_static -llzma -lgstadaptivedemux-1.0 -lgstallocators-1.0 -lgstanalytics-1.0 -lgstapp-1.0 -lgstaudio-1.0 -lgstbadaudio-1.0 -lgstbase-1.0 -lgstbasecamerabinsrc-1.0 -lgstcodecparsers-1.0 -lgstcodecs-1.0 -lgstcontroller-1.0 -lgstcuda-1.0 -lgstfft-1.0 -lgstinsertbin-1.0 -lgstisoff-1.0 -lgstmpegts-1.0 -lgstmse-1.0 -lgstnet-1.0 -lgstpbutils-1.0 -lgstphotography-1.0 -lgstplay-1.0 -lgstplayer-1.0 -lgstreamer-1.0 -lgstriff-1.0 -lgstrtp-1.0 -lgstrtsp-1.0 -lgstsctp-1.0 -lgstsdp-1.0 -lgsttag-1.0 -lgsttranscoder-1.0 -lgsturidownloader-1.0 -lgstvideo-1.0 -lgstwebrtc-1.0 -lopenh264 -lstdc++ -lglib-2.0 -lgio-2.0 -lgmodule-2.0 -lgobject-2.0 -lgthread-2.0 -lgirepository-2.0 -lffi -lpcre2-8 -lintl -ltegra_hal"
+
+FROM opencv-${TARGETARCH} AS builder
+
+CMD go build -ldflags "-linkmode 'external' -extldflags '-static'" -tags netgo,osusergo,customenv -o /build/wasmvision -buildvcs=false ./cmd/wasmvision

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ It provides a high-performance computer vision processing engine that is designe
 
 ## How it works
 
-- Capture images from a camera or video file
-- Process them using WebAssembly
+- Capture video from a camera, video file, or stream
+- Process the video frames using WebAssembly
 - Output the results to a stream or video file
 
 ```mermaid


### PR DESCRIPTION
This PR switches the builds and Docker image to use Alpine Linux.

In addition, it adds GStreamer to the wasmVision binary.

Thanks to a much more stringent static compilation using musl, it should have no external dependencies and run on any Linux distro.