### PR TITLE
runtime: truncate responses for now to keep strings shorter than 172 chars

### DIFF
--- a/runtime/hostfuncs.go
+++ b/runtime/hostfuncs.go
@@ -231,6 +231,9 @@ func httpPostImageFunc(ctx *cv.Context) func(*wypes.Store, wypes.String, wypes.S
 		}
 
 		val := v.(string)
+		if len(val) >= 172 {
+			val = val[:168] + "..."
+		}
 		res := make([]byte, len(val))
 		copy(res, val)
 


### PR DESCRIPTION
This PR modifies the response returned by the `wasmvision:platform/http` function `PostImage()` to keep the length less than 172 characters. For some reason the result is getting mangled when longer.