### PR TITLE
chore: update to OpenCV 4.11

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   test:
     runs-on: ubuntu-latest
-    container: ghcr.io/hybridgroup/opencv:4.10.0
+    container: ghcr.io/hybridgroup/opencv:4.11.0
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -25,39 +25,39 @@ jobs:
         uses: actions/cache/restore@v4
         id: cache-opencv-source
         with:
-          key: opencv-source-4100-windows-v1
+          key: opencv-source-4110-windows-v1
           path: |
-            ./opencv/opencv-4.10.0
-            ./opencv/opencv_contrib-4.10.0
+            ./opencv/opencv-4.11.0
+            ./opencv/opencv_contrib-4.11.0
       - name: Download OpenCV source
         if: steps.cache-opencv-source.outputs.cache-hit != 'true'
         shell: bash
         run: |
             mkdir -p ./opencv
-            curl -Lo ./opencv/opencv-4.10.0.zip https://github.com/opencv/opencv/archive/4.10.0.zip
-            curl -Lo ./opencv/opencv_contrib-4.10.0.zip https://github.com/opencv/opencv_contrib/archive/4.10.0.zip
+            curl -Lo ./opencv/opencv-4.11.0.zip https://github.com/opencv/opencv/archive/4.11.0.zip
+            curl -Lo ./opencv/opencv_contrib-4.11.0.zip https://github.com/opencv/opencv_contrib/archive/4.11.0.zip
       - name: Extract OpenCV source
         if: steps.cache-opencv-source.outputs.cache-hit != 'true'
         shell: bash
         run: |
             cd ./opencv
-            mkdir -p opencv-4.10.0
-            mkdir -p opencv_contrib-4.10.0
-            7z x opencv-4.10.0.zip
-            7z x opencv_contrib-4.10.0.zip
+            mkdir -p opencv-4.11.0
+            mkdir -p opencv_contrib-4.11.0
+            7z x opencv-4.11.0.zip
+            7z x opencv_contrib-4.11.0.zip
       - name: Save cached OpenCV source
         uses: actions/cache/save@v4
         if: steps.cache-opencv-source.outputs.cache-hit != 'true'
         with:
           key: ${{ steps.cache-opencv-source.outputs.cache-primary-key }}
           path: |
-            ./opencv/opencv-4.10.0
-            ./opencv/opencv_contrib-4.10.0
+            ./opencv/opencv-4.11.0
+            ./opencv/opencv_contrib-4.11.0
       - name: Restore cached OpenCV build
         uses: actions/cache/restore@v4
         id: cache-opencv-build
         with:
-          key: opencv-build-4100-windows-v1
+          key: opencv-build-4110-windows-v1
           path: |
             ./opencv/build
       - name: Build OpenCV
@@ -65,7 +65,7 @@ jobs:
         run: |
             mkdir -p ./opencv/build            
             cd ./opencv/build
-            cmake -G "MinGW Makefiles" -DENABLE_CXX11=ON -DOPENCV_EXTRA_MODULES_PATH="../opencv_contrib-4.10.0/modules" -DBUILD_SHARED_LIBS=OFF -DWITH_IPP=OFF -DWITH_MSMF=OFF -DBUILD_EXAMPLES=OFF -DBUILD_TESTS=OFF -DBUILD_PERF_TESTS=ON -DBUILD_opencv_java=OFF -DBUILD_opencv_python=OFF -DBUILD_opencv_python2=OFF -DBUILD_opencv_python3=OFF -DBUILD_DOCS=OFF -DENABLE_PRECOMPILED_HEADERS=OFF -DBUILD_opencv_saliency=OFF -DBUILD_opencv_wechat_qrcode=ON -DCPU_DISPATCH= -DOPENCV_GENERATE_PKGCONFIG=ON -DWITH_OPENCL_D3D11_NV=OFF -DOPENCV_ALLOCATOR_STATS_COUNTER_TYPE=int64_t -DOPENCV_ENABLE_NONFREE=ON -Wno-dev ../opencv-4.10.0
+            cmake -G "MinGW Makefiles" -DENABLE_CXX11=ON -DOPENCV_EXTRA_MODULES_PATH="../opencv_contrib-4.11.0/modules" -DBUILD_SHARED_LIBS=OFF -DWITH_IPP=OFF -DWITH_MSMF=OFF -DBUILD_EXAMPLES=OFF -DBUILD_TESTS=OFF -DBUILD_PERF_TESTS=ON -DBUILD_opencv_java=OFF -DBUILD_opencv_python=OFF -DBUILD_opencv_python2=OFF -DBUILD_opencv_python3=OFF -DBUILD_DOCS=OFF -DENABLE_PRECOMPILED_HEADERS=OFF -DBUILD_opencv_saliency=OFF -DBUILD_opencv_wechat_qrcode=ON -DCPU_DISPATCH= -DOPENCV_GENERATE_PKGCONFIG=ON -DWITH_OPENCL_D3D11_NV=OFF -DOPENCV_ALLOCATOR_STATS_COUNTER_TYPE=int64_t -DOPENCV_ENABLE_NONFREE=ON -Wno-dev ../opencv-4.11.0
             cmake --build . --target install
       - name: Save cached OpenCV build
         uses: actions/cache/save@v4
@@ -79,7 +79,7 @@ jobs:
             go env
             echo "CGO_CXXFLAGS=--std=c++11" >> $env:GITHUB_ENV
             echo "CGO_CPPFLAGS=-I${env:GITHUB_WORKSPACE}\opencv\build\install\include" >> $env:GITHUB_ENV
-            echo "CGO_LDFLAGS=-L${env:GITHUB_WORKSPACE}\opencv\build\install\x64\mingw\staticlib -lopencv_core4100 -lopencv_face4100 -lopencv_videoio4100 -lopencv_imgproc4100 -lopencv_highgui4100 -lopencv_imgcodecs4100 -lopencv_objdetect4100 -lopencv_features2d4100 -lopencv_video4100 -lopencv_dnn4100 -lopencv_xfeatures2d4100 -lopencv_plot4100 -lopencv_tracking4100 -lopencv_img_hash4100 -lopencv_calib3d4100 -lopencv_bgsegm4100 -lopencv_photo4100 -lopencv_aruco4100 -lopencv_wechat_qrcode4100 -lopencv_ximgproc4100 -lopencv_xphoto4100 -lopencv_flann4100 -static -lade -llibprotobuf -lIlmImf -llibpng -llibopenjp2 -llibwebp -llibtiff -llibjpeg-turbo -lzlib -lkernel32 -lgdi32 -lwinspool -lshell32 -lole32 -loleaut32 -luuid -lcomdlg32 -ladvapi32 -luser32" >> $env:GITHUB_ENV
+            echo "CGO_LDFLAGS=-L${env:GITHUB_WORKSPACE}\opencv\build\install\x64\mingw\staticlib -lopencv_core4110 -lopencv_face4110 -lopencv_videoio4110 -lopencv_imgproc4110 -lopencv_highgui4110 -lopencv_imgcodecs4110 -lopencv_objdetect4110 -lopencv_features2d4110 -lopencv_video4110 -lopencv_dnn4110 -lopencv_xfeatures2d4110 -lopencv_plot4110 -lopencv_tracking4110 -lopencv_img_hash4110 -lopencv_calib3d4110 -lopencv_bgsegm4110 -lopencv_photo4110 -lopencv_aruco4110 -lopencv_wechat_qrcode4110 -lopencv_ximgproc4110 -lopencv_xphoto4110 -lopencv_flann4110 -static -lade -llibprotobuf -lIlmImf -llibpng -llibopenjp2 -llibwebp -llibtiff -llibjpeg-turbo -lzlib -lkernel32 -lgdi32 -lwinspool -lshell32 -lole32 -loleaut32 -luuid -lcomdlg32 -ladvapi32 -luser32" >> $env:GITHUB_ENV
             echo "${env:GITHUB_WORKSPACE}/opencv/build/install/x64/mingw/bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
       - name: Run tests
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@
 #   docker buildx build -t wasmvision:dev --platform=linux/amd64,linux/arm64 .
 #
 # first stage: build the wasmvision binary
-FROM --platform=${TARGETPLATFORM} ghcr.io/hybridgroup/opencv:4.10.0-alpine-ffmpeg-gstreamer AS opencv
+FROM --platform=${TARGETPLATFORM} ghcr.io/hybridgroup/opencv:4.11.0-alpine-ffmpeg-gstreamer AS opencv
 
 RUN apk update && apk add --no-cache \
     util-linux-static util-linux-dev build-base \
@@ -24,7 +24,7 @@ RUN apk update && apk add --no-cache \
     gobject-introspection-dev libmount libeconf-dev
 
 # Install Go
-ARG GO_VERSION=1.23.2
+ARG GO_VERSION=1.23.4
 ARG TARGETARCH
 
 RUN wget https://golang.org/dl/go${GO_VERSION}.linux-${TARGETARCH}.tar.gz && \

--- a/Dockerfile-builder
+++ b/Dockerfile-builder
@@ -2,7 +2,7 @@
 #
 # running:
 # docker run --rm -v $(pwd):/src -v $(pwd)/build/amd64/:/build -a stdout -a stderr --platform linux/amd64 ghcr.io/wasmvision/wasmvision-static-builder
-FROM --platform=linux/amd64 ghcr.io/hybridgroup/opencv:4.10.0-alpine-ffmpeg-gstreamer AS opencv-amd64
+FROM --platform=linux/amd64 ghcr.io/hybridgroup/opencv:4.11.0-alpine-ffmpeg-gstreamer AS opencv-amd64
 
 RUN apk update && apk add --no-cache \
     util-linux-static util-linux-dev build-base \
@@ -15,7 +15,7 @@ RUN apk update && apk add --no-cache \
     gobject-introspection-dev libmount libeconf-dev
 
 # Install Go
-ARG GO_VERSION=1.23.2
+ARG GO_VERSION=1.23.4
 ARG TARGETARCH
 
 RUN wget https://golang.org/dl/go${GO_VERSION}.linux-${TARGETARCH}.tar.gz && \
@@ -34,7 +34,7 @@ ENV CGO_LDFLAGS="-static -L/usr/local/lib -lopencv_gapi -lopencv_stitching -lope
 CMD go build -ldflags "-linkmode 'external' -extldflags '-static'" -tags netgo,osusergo,customenv -o /build/wasmvision -buildvcs=false ./cmd/wasmvision
 
 
-FROM --platform=linux/arm64 ghcr.io/hybridgroup/opencv:4.10.0-alpine-ffmpeg-gstreamer AS opencv-arm64
+FROM --platform=linux/arm64 ghcr.io/hybridgroup/opencv:4.11.0-alpine-ffmpeg-gstreamer AS opencv-arm64
 
 RUN apk update && apk add --no-cache \
     util-linux-static util-linux-dev build-base \
@@ -47,7 +47,7 @@ RUN apk update && apk add --no-cache \
     gobject-introspection-dev libmount libeconf-dev
 
 # Install Go
-ARG GO_VERSION=1.23.2
+ARG GO_VERSION=1.23.4
 ARG TARGETARCH
 
 RUN wget https://golang.org/dl/go${GO_VERSION}.linux-${TARGETARCH}.tar.gz && \

--- a/cmd/wasmvision/version.go
+++ b/cmd/wasmvision/version.go
@@ -8,7 +8,7 @@ import (
 )
 
 var (
-	v   = "0.1.0"
+	v   = "0.2.0-dev"
 	sha string
 )
 

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.22.0
 require (
 	github.com/orsinium-labs/wypes v0.3.0
 	github.com/tetratelabs/wazero v1.8.1
-	gocv.io/x/gocv v0.39.1-0.20241021192257-dc6fbbedf935
+	gocv.io/x/gocv v0.40.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -38,5 +38,5 @@ github.com/urfave/cli/v2 v2.27.4 h1:o1owoI+02Eb+K107p27wEX9Bb8eqIoZCfLXloLUSWJ8=
 github.com/urfave/cli/v2 v2.27.4/go.mod h1:m4QzxcD2qpra4z7WhzEGn74WZLViBnMpb1ToCAKdGRQ=
 github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1 h1:gEOO8jv9F4OT7lGCjxCBTO/36wtF6j2nSip77qHd4x4=
 github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1/go.mod h1:Ohn+xnUBiLI6FVj/9LpzZWtj1/D6lUovWYBkxHVV3aM=
-gocv.io/x/gocv v0.39.1-0.20241021192257-dc6fbbedf935 h1:ka2VVhqHYj01Vt9K7owJoxQ/hEX50h9Qgkfn0a58ots=
-gocv.io/x/gocv v0.39.1-0.20241021192257-dc6fbbedf935/go.mod h1:zYdWMj29WAEznM3Y8NsU3A0TRq/wR/cy75jeUypThqU=
+gocv.io/x/gocv v0.40.0 h1:kGBu/UVj+dO6A9dhQmGOnCICSL7ke7b5YtX3R3azdXI=
+gocv.io/x/gocv v0.40.0/go.mod h1:zYdWMj29WAEznM3Y8NsU3A0TRq/wR/cy75jeUypThqU=

--- a/version.go
+++ b/version.go
@@ -1,7 +1,7 @@
 package wasmvision
 
 var (
-	version = "0.1.0"
+	version = "0.2.0-dev"
 	sha     string
 )
 


### PR DESCRIPTION
This PR updates wasmVision to use OpenCV `4.11` & GoCV `0.40`.