### PR TITLE
feature: add specific capture flag/type for ffmpeg

### DIFF
--- a/capture/ffmpeg.go
+++ b/capture/ffmpeg.go
@@ -1,0 +1,54 @@
+package capture
+
+import (
+	"github.com/wasmvision/wasmvision/cv"
+
+	"gocv.io/x/gocv"
+)
+
+type FFmpeg struct {
+	device  string
+	stream  *gocv.VideoCapture
+	retries int
+}
+
+func NewFFmpeg(device string) *FFmpeg {
+	return &FFmpeg{
+		device:  device,
+		retries: defaultRetries,
+	}
+}
+
+func (g *FFmpeg) Open() error {
+	stream, err := gocv.OpenVideoCaptureWithAPI(g.device, gocv.VideoCaptureFFmpeg)
+	if err != nil {
+		return err
+	}
+
+	g.stream = stream
+	return nil
+}
+
+func (g *FFmpeg) Close() error {
+	return g.stream.Close()
+}
+
+func (g *FFmpeg) Read() (*cv.Frame, error) {
+	img := gocv.NewMat()
+	if ok := g.stream.Read(&img); !ok {
+		g.retries--
+		if g.retries == 0 {
+			return &cv.Frame{}, ErrClosed
+		}
+
+		frame := cv.NewEmptyFrame()
+
+		return frame, nil
+	}
+
+	g.retries = defaultRetries
+
+	frame := cv.NewFrame(img)
+
+	return frame, nil
+}

--- a/cmd/wasmvision/main.go
+++ b/cmd/wasmvision/main.go
@@ -12,7 +12,7 @@ import (
 var (
 	runFlags = []cli.Flag{
 		&cli.StringFlag{Name: "source", Aliases: []string{"s"}, Value: "0", Usage: "video capture source to use. webcam id, file name, or stream (0 is the default webcam on most systems)"},
-		&cli.StringFlag{Name: "capture", Value: "auto", Usage: "video capture source type to use (auto, webcam, gstreamer)"},
+		&cli.StringFlag{Name: "capture", Value: "auto", Usage: "video capture source type to use (auto, ffmpeg, gstreamer, webcam)"},
 		&cli.StringFlag{Name: "output", Aliases: []string{"o"}, Value: "mjpeg", Usage: "output type (mjpeg, file)"},
 		&cli.StringFlag{Name: "destination", Aliases: []string{"d"}, Usage: "output destination (port, file path)"},
 		&cli.StringSliceFlag{

--- a/cmd/wasmvision/run.go
+++ b/cmd/wasmvision/run.go
@@ -86,6 +86,11 @@ func run(cCtx *cli.Context) error {
 		if err := device.Open(); err != nil {
 			return fmt.Errorf("failed opening video capture stream: %w", err)
 		}
+	case "ffmpeg":
+		device = capture.NewFFmpeg(source)
+		if err := device.Open(); err != nil {
+			return fmt.Errorf("failed opening video capture stream: %w", err)
+		}
 	default:
 		return fmt.Errorf("unknown capture type %v", cap)
 	}


### PR DESCRIPTION
This PR adds a capture flag `ffmpeg` so you can make it explicit exactly which capture type to use, instead of always having  to infer it.