### PR TITLE
fix: add missing blurc processor from list of known processors

### DIFF
--- a/guest/processors.go
+++ b/guest/processors.go
@@ -26,6 +26,11 @@ var KnownProcessors = map[string]ProcessorFile{
 		Filename: "blur.wasm",
 		URL:      "https://github.com/wasmvision/wasmvision/raw/refs/heads/main/processors/blur.wasm",
 	},
+	"blurc": {
+		Alias:    "blurc",
+		Filename: "blurc.wasm",
+		URL:      "https://github.com/wasmvision/wasmvision/raw/refs/heads/main/processors/blurc.wasm",
+	},
 	"blurrs": {
 		Alias:    "blurrs",
 		Filename: "blurrs.wasm",


### PR DESCRIPTION
This PR is to add the missing `blurc.wasm` processor from list of known processors available for auto-download.