### PR TITLE
feature: add MCP resource server

### DIFF
--- a/cmd/wasmvision/flags.go
+++ b/cmd/wasmvision/flags.go
@@ -27,6 +27,9 @@ var (
 	downloadProcessors bool
 	downloadModels     bool
 
+	mcpEnabled bool
+	mcpPort    string
+
 	runFlags = []cli.Flag{
 		&cli.StringFlag{Name: "file",
 			Aliases:     []string{"f"},
@@ -112,6 +115,18 @@ var (
 			Usage:       "automatically download known models (default: true)",
 			Sources:     cli.NewValueSourceChain(toml.TOML("models.downloads", configSource), yaml.YAML("models.downloads", configSource)),
 			Destination: &downloadModels,
+		},
+		&cli.BoolFlag{Name: "mcp-server",
+			Value:       true,
+			Usage:       "enable MCP server (default: false)",
+			Sources:     cli.NewValueSourceChain(toml.TOML("server.mcp-enable", configSource), yaml.YAML("server.mcp-enable", configSource)),
+			Destination: &mcpEnabled,
+		},
+		&cli.StringFlag{Name: "mcp-port",
+			Value:       ":5001",
+			Usage:       "port for MCP server (default: :5001)",
+			Sources:     cli.NewValueSourceChain(toml.TOML("server.mcp-port", configSource), yaml.YAML("server.mcp-port", configSource)),
+			Destination: &mcpPort,
 		},
 	}
 

--- a/engine/mcp.go
+++ b/engine/mcp.go
@@ -1,0 +1,139 @@
+package engine
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"log/slog"
+	"net"
+	"net/url"
+	"sync"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+	"github.com/wasmvision/wasmvision"
+	"github.com/wasmvision/wasmvision/cv"
+	"gocv.io/x/gocv"
+)
+
+// MCPServer represents a MCP server currently providing a resource of the frames
+// being processed by wasmVision.
+type MCPServer struct {
+	mcpServer    *server.MCPServer
+	sseServer    *server.SSEServer
+	Port         string
+	frames       chan *cv.Frame
+	currentFrame gocv.Mat
+	frameMut     sync.Mutex
+}
+
+// NewMCPServer creates a new MCPServer instance with the given port.
+func NewMCPServer(port string) *MCPServer {
+	return &MCPServer{
+		Port:         port,
+		frames:       make(chan *cv.Frame, framebufferSize),
+		currentFrame: gocv.NewMat(),
+	}
+}
+
+// Start starts the NewMCPServer server.
+func (s *MCPServer) Start() error {
+	s.mcpServer = server.NewMCPServer("wasmvision", wasmvision.Version(),
+		server.WithResourceCapabilities(false, false))
+	s.sseServer = server.NewSSEServer(s.mcpServer,
+		server.WithBaseURL(getURL(s.Port)),
+	)
+
+	resource := mcp.NewResource(
+		"images://output",
+		"output",
+		mcp.WithResourceDescription("Current output image frame"),
+		mcp.WithMIMEType("image/jpeg"),
+	)
+
+	// Add resource with its handler
+	s.mcpServer.AddResource(resource, func(ctx context.Context, request mcp.ReadResourceRequest) ([]mcp.ResourceContents, error) {
+		s.frameMut.Lock()
+		defer s.frameMut.Unlock()
+
+		// Create a copy of the current frame for encoding
+		frameCopy := gocv.NewMat()
+		defer frameCopy.Close()
+		s.currentFrame.CopyTo(&frameCopy)
+
+		buf, err := gocv.IMEncode(".jpg", frameCopy)
+		if err != nil {
+			slog.Error(fmt.Sprintf("error encoding frame: %v", err))
+			return nil, err
+		}
+		defer buf.Close()
+
+		encodedImage := base64.StdEncoding.EncodeToString(buf.GetBytes())
+
+		return []mcp.ResourceContents{
+			mcp.BlobResourceContents{
+				URI:      "images://output",
+				MIMEType: "image/jpeg",
+				Blob:     encodedImage,
+			},
+		}, nil
+	})
+
+	go s.sseServer.Start(getPort(s.Port))
+	go s.publishFrames()
+
+	return nil
+}
+
+// Close closes the MCPServer server.
+func (s *MCPServer) Close() {
+	close(s.frames)
+	if s.sseServer != nil {
+		s.sseServer.Shutdown(context.Background())
+	}
+}
+
+// Publish publishes a frame to the MJPEG stream.
+func (s *MCPServer) Publish(frm *cv.Frame) error {
+	s.frames <- frm
+	return nil
+}
+
+func (s *MCPServer) publishFrames() {
+	for frame := range s.frames {
+		// if there is outstanding request for frame resource, update it
+		s.frameMut.Lock()
+		frame.Image.CopyTo(&s.currentFrame)
+		s.frameMut.Unlock()
+	}
+}
+
+func getURL(port string) string {
+	if port == "" {
+		return "http://localhost:5001"
+	}
+	if port[0] == ':' {
+		return fmt.Sprintf("http://localhost%s", port)
+	}
+	return port
+}
+
+func getPort(port string) string {
+	if port == "" {
+		return ":5001"
+	}
+	if port[0] == ':' {
+		return port
+	}
+
+	u, err := url.Parse(port)
+	if err != nil {
+		return ":5001"
+	}
+
+	_, p, _ := net.SplitHostPort(u.Host)
+	if p == "" {
+		return ":5001"
+	}
+	return ":" + p
+}

--- a/engine/mcp_test.go
+++ b/engine/mcp_test.go
@@ -1,0 +1,73 @@
+package engine
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/wasmvision/wasmvision/cv"
+	"gocv.io/x/gocv"
+)
+
+func TestMCPServer(t *testing.T) {
+	t.Run("new MCP server", func(t *testing.T) {
+		port := ":8081"
+
+		s := NewMCPServer(port)
+
+		if s.Port != port {
+			t.Errorf("unexpected port: %s", s.Port)
+		}
+
+		if s.frames == nil {
+			t.Errorf("unexpected nil frames")
+		}
+	})
+}
+
+func TestMCPServerStart(t *testing.T) {
+	t.Run("start MCP server start", func(t *testing.T) {
+		port := ":8081"
+
+		s := NewMCPServer(port)
+
+		s.Start()
+		defer s.Close()
+		img := gocv.IMRead("../images/wasmvision-logo.png", gocv.IMReadColor)
+		frm := cv.NewFrame(img)
+		if err := s.Publish(frm); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+}
+
+func TestMCPServerEndpoint(t *testing.T) {
+	t.Run("start MCP server start", func(t *testing.T) {
+		port := "http://localhost:8081"
+
+		s := NewMCPServer(port)
+		s.Start()
+		defer s.Close()
+
+		sseResp, err := http.Get(fmt.Sprintf("%s/sse", port))
+		if err != nil {
+			t.Fatalf("Failed to connect to SSE endpoint: %v", err)
+		}
+		defer sseResp.Body.Close()
+
+		buf := make([]byte, 1024)
+		n, err := sseResp.Body.Read(buf)
+		if err != nil {
+			t.Fatalf("Failed to read SSE response body: %v", err)
+		}
+
+		if n == 0 {
+			t.Fatalf("SSE response body is empty")
+		}
+
+		if !strings.Contains(string(buf[:n]), "event: endpoint") {
+			t.Fatalf("SSE response body does not contain event: endpoint")
+		}
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 require (
 	github.com/hashicorp/go-getter/v2 v2.2.3
 	github.com/hybridgroup/mjpeg v0.0.0-20140228234708-4680f319790e
+	github.com/mark3labs/mcp-go v0.15.0
 	github.com/orsinium-labs/tinytest v1.0.0
 	github.com/urfave/cli-altsrc/v3 v3.0.0-alpha2.0.20250228131929-8cc6e0481655
 	github.com/urfave/cli/v3 v3.0.0-beta1.0.20250209232119-706f78edb6b4
@@ -22,6 +23,7 @@ require (
 	github.com/BurntSushi/toml v1.5.0 // indirect
 	github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d // indirect
 	github.com/google/go-cmp v0.5.9 // indirect
+	github.com/google/uuid v1.6.0 // indirect
 	github.com/hashicorp/errwrap v1.0.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-multierror v1.1.0 // indirect
@@ -31,5 +33,6 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/mitchellh/go-testing-interface v1.14.1 // indirect
 	github.com/ulikunitz/xz v0.5.10 // indirect
+	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9neXJWAZQ=
@@ -22,6 +24,8 @@ github.com/hybridgroup/mjpeg v0.0.0-20140228234708-4680f319790e h1:xCcwD5FOXul+j
 github.com/hybridgroup/mjpeg v0.0.0-20140228234708-4680f319790e/go.mod h1:eagM805MRKrioHYuU7iKLUyFPVKqVV6um5DAvCkUtXs=
 github.com/klauspost/compress v1.15.11 h1:Lcadnb3RKGin4FYM/orgq0qde+nc15E5Cbqg4B9Sx9c=
 github.com/klauspost/compress v1.15.11/go.mod h1:QPwzmACJjUTFsnSHH934V6woptycfrDDJnH7hvFVbGM=
+github.com/mark3labs/mcp-go v0.15.0 h1:lViiC4dk6chJHZccezaTzZLMOQVUXJDGNQPtzExr5NQ=
+github.com/mark3labs/mcp-go v0.15.0/go.mod h1:xBB350hekQsJAK7gJAii8bcEoWemboLm2mRm5/+KBaU=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-testing-interface v1.14.1 h1:jrgshOhYAUVNMAJiKbEu7EqAwgJJ2JqpQmpLJOu07cU=
@@ -42,6 +46,8 @@ github.com/urfave/cli-altsrc/v3 v3.0.0-alpha2.0.20250228131929-8cc6e0481655 h1:h
 github.com/urfave/cli-altsrc/v3 v3.0.0-alpha2.0.20250228131929-8cc6e0481655/go.mod h1:xwYmypA98PqRCPRltmf6+BeYQ4+fq8s7Lai2u0x8qdo=
 github.com/urfave/cli/v3 v3.0.0-beta1.0.20250209232119-706f78edb6b4 h1:Y8+7IalO9ucv96kB0jGLN35ydjOIyb6UiqWTe8aROvQ=
 github.com/urfave/cli/v3 v3.0.0-beta1.0.20250209232119-706f78edb6b4/go.mod h1:FJSKtM/9AiiTOJL4fJ6TbMUkxBXn7GO9guZqoZtpYpo=
+github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=
+github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
 gocv.io/x/gocv v0.41.0 h1:KM+zRXUP28b6dHfhy+4JxDODbCNQNtLg8kio+YE7TqA=
 gocv.io/x/gocv v0.41.0/go.mod h1:zYdWMj29WAEznM3Y8NsU3A0TRq/wR/cy75jeUypThqU=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=


### PR DESCRIPTION
This PR is to add an experimental feature by providing an MCP server to allow for integration with various machine learning systems.

This first implementation adds a resource for `images://output` that returns the current output image from the running processing pipeline. The returned image data is MIME type of `image/jpeg` and UUencoded.

The MCP server uses the "HTTP with SSE" transport to facilitate being used in various networking related scenarios.

https://modelcontextprotocol.io/docs/concepts/resources