### PR TITLE
mcp: use messages (plural) as messages endpoint to match 'standard'

### DIFF
--- a/engine/mcp.go
+++ b/engine/mcp.go
@@ -63,6 +63,7 @@ func (s *MCPServer) Start() error {
 		server.WithResourceCapabilities(false, false))
 	s.sseServer = server.NewSSEServer(s.mcpServer,
 		server.WithBaseURL(getURL(s.Port)),
+		server.WithMessageEndpoint("/messages"),
 	)
 
 	s.mcpServer.AddResource(imagesInputResource, func(ctx context.Context, request mcp.ReadResourceRequest) ([]mcp.ResourceContents, error) {


### PR DESCRIPTION
This PR modifies the MCP server's messages endpoint to use `messages` (plural) to match 'standard' of other MCP Servers.

For example, https://github.com/modelcontextprotocol/python-sdk/blob/main/src/mcp/server/sse.py#L9