### PR TITLE
fix: add missing captions processor to list of known processors

### DIFF
--- a/guest/processors.go
+++ b/guest/processors.go
@@ -41,6 +41,11 @@ var KnownProcessors = map[string]ProcessorFile{
 		Filename: "candy.wasm",
 		URL:      "https://github.com/wasmvision/wasmvision/raw/refs/heads/main/processors/candy.wasm",
 	},
+	"captions": {
+		Alias:    "captions",
+		Filename: "captions.wasm",
+		URL:      "https://github.com/wasmvision/wasmvision/raw/refs/heads/main/processors/captions.wasm",
+	},
 	"faceblur": {
 		Alias:    "faceblur",
 		Filename: "faceblur.wasm",

--- a/processors/README.md
+++ b/processors/README.md
@@ -32,6 +32,10 @@ Processor written in Rust that performs a blur on the image frame.
 
 Processor written in Go that performs fast neural style transfer.
 
+## captions.wasm
+
+Processor written in Go that adds text captions to the final output image.
+
 ## gaussianblur.wasm
 
 ![gaussianblur](../images/gaussianblur-processor.png)

--- a/processors/captions/README.md
+++ b/processors/captions/README.md
@@ -1,8 +1,6 @@
 # captions
 
-![captions](../../images/captions-processor.png)
-
-wasmVision processor that adds captions to the final output image. 
+wasmVision processor that adds text captions to the final output image.
 
 ## How to build
 


### PR DESCRIPTION
This PR is to add the missing "captions" processor to list of known processors. It also removes link to a non-existing image from the README for the "captions" processor.