### PR TITLE
fix: correctly handle closing of capture frame when it is the same as the processed frame

### DIFF
--- a/cmd/wasmvision/run.go
+++ b/cmd/wasmvision/run.go
@@ -192,6 +192,10 @@ func run(ctx context.Context, cmd *cli.Command) error {
 		case "file":
 			videoWriter.Write(outframe)
 		}
-		frame.Close()
+
+		// Close the original frame unless it was returned by the output
+		if frame.ID.Unwrap() != outframe.ID.Unwrap() {
+			frame.Close()
+		}
 	}
 }

--- a/engine/mjpeg.go
+++ b/engine/mjpeg.go
@@ -69,6 +69,7 @@ func (s *MJPEGStream) publishFrames() {
 		buf, err := gocv.IMEncode(".jpg", frame.Image)
 		if err != nil {
 			slog.Error(fmt.Sprintf("error writing frame: %v", err))
+			continue
 		}
 
 		s.stream.UpdateJPEG(buf.GetBytes())


### PR DESCRIPTION
This PR corrects the crash from closing capture frames when they are the same as the processed frame returns, by not closing them.