### PR TITLE
fix: prevent mjpeg streams from closing

### DIFF
--- a/engine/mjpeg.go
+++ b/engine/mjpeg.go
@@ -39,7 +39,7 @@ func (s *MJPEGStream) Start() error {
 	s.server = &http.Server{
 		Addr:         s.Port,
 		ReadTimeout:  60 * time.Second,
-		WriteTimeout: 60 * time.Second,
+		WriteTimeout: 0 * time.Second,
 	}
 
 	go s.publishFrames()

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/wasmvision/wasmvision
 
 go 1.23.2
 
-toolchain go1.24.1
-
 require (
 	github.com/orsinium-labs/wypes v0.3.0
 	github.com/tetratelabs/wazero v1.9.0
@@ -12,7 +10,7 @@ require (
 
 require (
 	github.com/hashicorp/go-getter/v2 v2.2.3
-	github.com/hybridgroup/mjpeg v0.0.0-20140228234708-4680f319790e
+	github.com/hybridgroup/mjpeg v0.0.0-20250330094202-16d243df0e35
 	github.com/mark3labs/mcp-go v0.15.0
 	github.com/orsinium-labs/tinytest v1.0.0
 	github.com/urfave/cli-altsrc/v3 v3.0.0-alpha2.0.20250228131929-8cc6e0481655

--- a/go.sum
+++ b/go.sum
@@ -20,8 +20,8 @@ github.com/hashicorp/go-safetemp v1.0.0 h1:2HR189eFNrjHQyENnQMMpCiBAsRxzbTMIgBhE
 github.com/hashicorp/go-safetemp v1.0.0/go.mod h1:oaerMy3BhqiTbVye6QuFhFtIceqFoDHxNAB65b+Rj1I=
 github.com/hashicorp/go-version v1.6.0 h1:feTTfFNnjP967rlCxM/I9g701jU+RN74YKx2mOkIeek=
 github.com/hashicorp/go-version v1.6.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
-github.com/hybridgroup/mjpeg v0.0.0-20140228234708-4680f319790e h1:xCcwD5FOXul+j1dn8xD16nbrhJkkum/Cn+jTd/u1LhY=
-github.com/hybridgroup/mjpeg v0.0.0-20140228234708-4680f319790e/go.mod h1:eagM805MRKrioHYuU7iKLUyFPVKqVV6um5DAvCkUtXs=
+github.com/hybridgroup/mjpeg v0.0.0-20250330094202-16d243df0e35 h1:bTJxSThEisMQhK+VQUaHK72RqcUr6hXzYtRnuJByiQo=
+github.com/hybridgroup/mjpeg v0.0.0-20250330094202-16d243df0e35/go.mod h1:GAKUz9knlg+UB2oaCqgLTlWdsuVlf7ieJGt+oZzL4eY=
 github.com/klauspost/compress v1.15.11 h1:Lcadnb3RKGin4FYM/orgq0qde+nc15E5Cbqg4B9Sx9c=
 github.com/klauspost/compress v1.15.11/go.mod h1:QPwzmACJjUTFsnSHH934V6woptycfrDDJnH7hvFVbGM=
 github.com/mark3labs/mcp-go v0.15.0 h1:lViiC4dk6chJHZccezaTzZLMOQVUXJDGNQPtzExr5NQ=


### PR DESCRIPTION
This PR is to address the problem with mjpeg streams closing prematurely. 

It also updates the `mjpeg` package to newer version with some minor improvements, such as sending the `X-Timecode` header for the `image/jpeg` data being streamed for clients that can utilize it.