### PR TITLE
feature: check to see if CUDA is actually present and working

### DIFF
--- a/Dockerfile-cuda
+++ b/Dockerfile-cuda
@@ -8,7 +8,7 @@ ENV PATH="${PATH}:/go/bin"
 COPY . /src
 WORKDIR /src
 
-RUN go build -o /run/wasmvision ./cmd/wasmvision
+RUN go build -tags cuda -o /run/wasmvision ./cmd/wasmvision
 
 COPY ./processors/*.wasm /processors/
 

--- a/cmd/wasmvision/run.go
+++ b/cmd/wasmvision/run.go
@@ -61,6 +61,13 @@ func run(ctx context.Context, cmd *cli.Command) error {
 		settings[parts[0]] = parts[1]
 	}
 
+	if enableCUDA {
+		if !runtime.CheckCUDA() {
+			return fmt.Errorf("CUDA not available on this system")
+		}
+		slog.Info("CUDA enabled")
+	}
+
 	// load wasm runtime
 	r := runtime.New(ctx, runtime.InterpreterConfig{
 		ProcessorsDir: processorsDir,

--- a/docs/cuda.md
+++ b/docs/cuda.md
@@ -21,7 +21,7 @@ https://github.com/hybridgroup/gocv/blob/release/cuda/README.md#installing-cuda
 Once you have installed the needed versions of CUDA and OpenCV, actually building the executable is much easier.
 
 ```shell
-go install ./cmd/wasmvision
+go install -tags cuda ./cmd/wasmvision
 ```
 
 ### Running

--- a/runtime/cuda.go
+++ b/runtime/cuda.go
@@ -1,0 +1,19 @@
+//go:build cuda
+
+package runtime
+
+import (
+	"log/slog"
+
+	"gocv.io/x/gocv/cuda"
+)
+
+func CheckCUDA() bool {
+	devices := cuda.GetCudaEnabledDeviceCount()
+	if devices == 0 {
+		slog.Warn("No CUDA devices found")
+		return false
+	}
+	slog.Info("CUDA devices found", slog.Int("count", devices))
+	return true
+}

--- a/runtime/nocuda.go
+++ b/runtime/nocuda.go
@@ -1,0 +1,7 @@
+//go:build !cuda
+
+package runtime
+
+func CheckCUDA() bool {
+	return false
+}


### PR DESCRIPTION
This PR adds a check when trying to run wasmVision with CUDA enabled to see if CUDA is actually present and working on that system.

Adds a build tag `cuda` to guard CPU-only builds from needing any CUDA dependencies for current static builds.