### PR TITLE
feature: display available DNN backends from wasmvision info command

### DIFF
--- a/cmd/wasmvision/info.go
+++ b/cmd/wasmvision/info.go
@@ -24,6 +24,8 @@ func info(ctx context.Context, cmd *cli.Command) error {
 	printWriterBackends()
 	fmt.Println()
 
+	printDNNBackends()
+
 	return nil
 }
 

--- a/cmd/wasmvision/info_cpu.go
+++ b/cmd/wasmvision/info_cpu.go
@@ -1,0 +1,12 @@
+//go:build !cuda
+
+package main
+
+import (
+	"fmt"
+)
+
+func printDNNBackends() {
+	fmt.Print("CV DNN backends:  ")
+	fmt.Println("CPU")
+}

--- a/cmd/wasmvision/info_cuda.go
+++ b/cmd/wasmvision/info_cuda.go
@@ -1,0 +1,25 @@
+//go:build cuda
+
+package main
+
+import (
+	"fmt"
+
+	"gocv.io/x/gocv/cuda"
+)
+
+func printDNNBackends() {
+	fmt.Print("CV DNN backends:  ")
+	fmt.Print("CPU")
+	fmt.Println(" GPU")
+	devices := cuda.GetCudaEnabledDeviceCount()
+	switch devices {
+	case 0:
+		fmt.Print("  No CUDA devices found")
+	default:
+		for i := 0; i < devices; i++ {
+			fmt.Print("  ")
+			cuda.PrintShortCudaDeviceInfo(i)
+		}
+	}
+}


### PR DESCRIPTION
This PR modifies the `wasmvision info` command to display available DNN backends.

```shell
$ wasmvision info                                                                    
wasmVision version 0.3.1 linux/amd64   
Camera backends:  GSTREAMER V4L2 UEYE OBSENSOR           
Stream backends:  FFMPEG GSTREAMER INTEL_MFX V4L2 CV_IMAGES CV_MJPEG
Writer backends:  FFMPEG GSTREAMER INTEL_MFX CV_IMAGES CV_MJPEG
CV DNN backends:  CPU
```

```shell
$ wasmvision info                                                                                                                                                        
wasmVision version 0.3.1 linux/amd64                                                                                                                                     
Camera backends:  GSTREAMER V4L2 UEYE OBSENSOR                                                                                                                           
Stream backends:  FFMPEG GSTREAMER INTEL_MFX V4L2 CV_IMAGES CV_MJPEG                                                                                                     
Writer backends:  FFMPEG GSTREAMER INTEL_MFX CV_IMAGES CV_MJPEG                                                                                                          
CV DNN backends:  CPU GPU                                                                                                                                                
  Device 0:  "NVIDIA GeForce RTX 4070 Laptop GPU"  7836Mb, sm_89, Driver/Runtime ver.12.60/12.50
```
