### PR TITLE
fix/feature: correctly handle well-known processors that include .wasm file extension

### DIFF
--- a/cmd/wasmvision/listall.go
+++ b/cmd/wasmvision/listall.go
@@ -46,8 +46,8 @@ func printModels() {
 }
 
 func printProcessors() {
-	s := make([]keyValue, 0, len(guest.KnownProcessors))
-	for k, v := range guest.KnownProcessors {
+	s := make([]keyValue, 0, len(guest.KnownProcessors()))
+	for k, v := range guest.KnownProcessors() {
 		s = append(s, keyValue{k, v.Alias})
 	}
 

--- a/guest/processors_test.go
+++ b/guest/processors_test.go
@@ -10,11 +10,19 @@ func TestWellKnownProcessor(t *testing.T) {
 		if !ProcessorWellKnown("candy") {
 			t.Errorf("processor candy not found")
 		}
+
+		if !ProcessorWellKnown("candy.wasm") {
+			t.Errorf("processor candy.wasm not found")
+		}
 	})
 
 	t.Run("unknown processor", func(t *testing.T) {
 		if ProcessorWellKnown("unknown") {
 			t.Errorf("processor unknown found")
+		}
+
+		if ProcessorWellKnown("unknown.wasm") {
+			t.Errorf("processor unknown.wasm found")
 		}
 	})
 }


### PR DESCRIPTION
This PR is to correctly handle using well-known processors that include .wasm file extension.

Previously if you tried to use "blur.wasm" and expected it to download the well-known processor of that name, it would give an error message. You were expected to use the name "blur" only without extension.

With this PR you can say either "blur" or "blur.wasm" and wasmVision will interpret that as meaning that you wish to use the well-known processor of the same name.