### PR TITLE
refactor: split out some of the functions from the run command for better readability

### DIFF
--- a/capture/capture.go
+++ b/capture/capture.go
@@ -2,6 +2,7 @@ package capture
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/wasmvision/wasmvision/cv"
 )
@@ -15,4 +16,36 @@ type Capture interface {
 	Open() error
 	Close() error
 	Read() (*cv.Frame, error)
+}
+
+// OpenDevice opens a capture device based on the specified type and source.
+// It returns a Capture interface that can be used to read frames from the device.
+// The captureDevice parameter can be "auto", "webcam", "gstreamer", or "ffmpeg".
+// The source parameter is the input source for the capture device.
+// If the capture device type is not recognized, an error is returned.
+// If the capture device fails to open, an error is returned.
+func OpenDevice(captureDevice, source string) (Capture, error) {
+	var device Capture
+
+	switch captureDevice {
+	case "auto", "webcam":
+		device = NewWebcam(source)
+		if err := device.Open(); err != nil {
+			return nil, fmt.Errorf("failed opening video capture: %w", err)
+		}
+	case "gstreamer":
+		device = NewGStreamer(source)
+		if err := device.Open(); err != nil {
+			return nil, fmt.Errorf("failed opening video capture stream: %w", err)
+		}
+	case "ffmpeg":
+		device = NewFFmpeg(source)
+		if err := device.Open(); err != nil {
+			return nil, fmt.Errorf("failed opening video capture stream: %w", err)
+		}
+	default:
+		return nil, fmt.Errorf("unknown capture type %v", captureDevice)
+	}
+
+	return device, nil
 }

--- a/cmd/wasmvision/run.go
+++ b/cmd/wasmvision/run.go
@@ -13,13 +13,13 @@ import (
 	"github.com/wasmvision/wasmvision/runtime"
 )
 
+var (
+	mjpegstream *engine.MJPEGStream
+	videoWriter *engine.VideoWriter
+)
+
 func run(ctx context.Context, cmd *cli.Command) error {
-	if len(pipeline) > 0 {
-		list := pipeline[0]
-		list = strings.TrimLeft(list, "[")
-		list = strings.TrimRight(list, "]")
-		processors = strings.Split(list, " ")
-	}
+	handlePipelineParams()
 	if len(processors) == 0 {
 		fmt.Println("No wasm processors specified")
 		os.Exit(1)
@@ -33,25 +33,12 @@ func run(ctx context.Context, cmd *cli.Command) error {
 		modelsDir = DefaultModelPath()
 	}
 
-	switch loggingLevel {
-	case "error":
-		slog.SetLogLoggerLevel(slog.LevelError)
-	case "warn":
-		slog.SetLogLoggerLevel(slog.LevelWarn)
-	case "info":
-		slog.SetLogLoggerLevel(slog.LevelInfo)
-	case "debug":
-		slog.SetLogLoggerLevel(slog.LevelDebug)
-	default:
-		return fmt.Errorf("unknown log level %v", loggingLevel)
+	if err := setLoggingLevel(); err != nil {
+		return err
 	}
 
-	if len(configuration) > 0 {
-		list := configuration[0]
-		list = strings.TrimLeft(list, "[")
-		list = strings.TrimRight(list, "]")
-		config = strings.Split(list, " ")
-	}
+	handleConfigurationParams()
+
 	settings := map[string]string{}
 	for _, c := range config {
 		parts := strings.Split(c, "=")
@@ -86,34 +73,12 @@ func run(ctx context.Context, cmd *cli.Command) error {
 	}
 
 	// Open the capture device.
-	var device capture.Capture
-
-	switch captureDevice {
-	case "auto", "webcam":
-		device = capture.NewWebcam(source)
-		if err := device.Open(); err != nil {
-			return fmt.Errorf("failed opening video capture: %w", err)
-		}
-	case "gstreamer":
-		device = capture.NewGStreamer(source)
-		if err := device.Open(); err != nil {
-			return fmt.Errorf("failed opening video capture stream: %w", err)
-		}
-	case "ffmpeg":
-		device = capture.NewFFmpeg(source)
-		if err := device.Open(); err != nil {
-			return fmt.Errorf("failed opening video capture stream: %w", err)
-		}
-	default:
-		return fmt.Errorf("unknown capture type %v", captureDevice)
+	device, err := capture.OpenDevice(captureDevice, source)
+	if err != nil {
+		return fmt.Errorf("failed to open capture device: %w", err)
 	}
 
 	defer device.Close()
-
-	var (
-		mjpegstream *engine.MJPEGStream
-		videoWriter *engine.VideoWriter
-	)
 
 	switch output {
 	case "mjpeg":
@@ -218,5 +183,40 @@ func run(ctx context.Context, cmd *cli.Command) error {
 		if frame.ID.Unwrap() != outframe.ID.Unwrap() {
 			frame.Close()
 		}
+	}
+}
+
+func handlePipelineParams() {
+	if len(pipeline) > 0 {
+		list := pipeline[0]
+		list = strings.TrimLeft(list, "[")
+		list = strings.TrimRight(list, "]")
+		processors = strings.Split(list, " ")
+	}
+}
+
+func setLoggingLevel() error {
+	switch loggingLevel {
+	case "error":
+		slog.SetLogLoggerLevel(slog.LevelError)
+	case "warn":
+		slog.SetLogLoggerLevel(slog.LevelWarn)
+	case "info":
+		slog.SetLogLoggerLevel(slog.LevelInfo)
+	case "debug":
+		slog.SetLogLoggerLevel(slog.LevelDebug)
+	default:
+		return fmt.Errorf("unknown log level %v", loggingLevel)
+	}
+
+	return nil
+}
+
+func handleConfigurationParams() {
+	if len(configuration) > 0 {
+		list := configuration[0]
+		list = strings.TrimLeft(list, "[")
+		list = strings.TrimRight(list, "]")
+		config = strings.Split(list, " ")
 	}
 }


### PR DESCRIPTION
This PR is refactor the run command by splitting out some of the functions for better readability.
