### PR TITLE
build: tell CMake to build even with older file version

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -67,7 +67,7 @@ jobs:
         run: |
             mkdir -p ./opencv/build            
             cd ./opencv/build
-            cmake -G "MinGW Makefiles" -DENABLE_CXX11=ON -DOPENCV_EXTRA_MODULES_PATH="../opencv_contrib-4.11.0/modules" -DBUILD_SHARED_LIBS=OFF -DWITH_IPP=OFF -DWITH_MSMF=OFF -DBUILD_EXAMPLES=OFF -DBUILD_TESTS=OFF -DBUILD_PERF_TESTS=ON -DBUILD_opencv_java=OFF -DBUILD_opencv_python=OFF -DBUILD_opencv_python2=OFF -DBUILD_opencv_python3=OFF -DBUILD_DOCS=OFF -DENABLE_PRECOMPILED_HEADERS=OFF -DBUILD_opencv_saliency=OFF -DBUILD_opencv_wechat_qrcode=ON -DCPU_DISPATCH= -DOPENCV_GENERATE_PKGCONFIG=ON -DWITH_OPENCL_D3D11_NV=OFF -DOPENCV_ALLOCATOR_STATS_COUNTER_TYPE=int64_t -DOPENCV_ENABLE_NONFREE=ON -Wno-dev ../opencv-4.11.0
+            cmake -G "MinGW Makefiles" -DCMAKE_POLICY_VERSION_MINIMUM="3.5" -DENABLE_CXX11=ON -DOPENCV_EXTRA_MODULES_PATH="../opencv_contrib-4.11.0/modules" -DBUILD_SHARED_LIBS=OFF -DWITH_IPP=OFF -DWITH_MSMF=OFF -DBUILD_EXAMPLES=OFF -DBUILD_TESTS=OFF -DBUILD_PERF_TESTS=ON -DBUILD_opencv_java=OFF -DBUILD_opencv_python=OFF -DBUILD_opencv_python2=OFF -DBUILD_opencv_python3=OFF -DBUILD_DOCS=OFF -DENABLE_PRECOMPILED_HEADERS=OFF -DBUILD_opencv_saliency=OFF -DBUILD_opencv_wechat_qrcode=ON -DCPU_DISPATCH= -DOPENCV_GENERATE_PKGCONFIG=ON -DWITH_OPENCL_D3D11_NV=OFF -DOPENCV_ALLOCATOR_STATS_COUNTER_TYPE=int64_t -DOPENCV_ENABLE_NONFREE=ON -Wno-dev ../opencv-4.11.0
             cmake --build . --target install
       - name: Save cached OpenCV build
         uses: actions/cache/save@v4


### PR DESCRIPTION
This PR is tell CMake to build even with older file version to fix the Windows CI build.