### PR TITLE
fix: exit on fatal processor error instead of just continuing.

### DIFF
--- a/cmd/wasmvision/run.go
+++ b/cmd/wasmvision/run.go
@@ -161,7 +161,7 @@ func run(ctx context.Context, cmd *cli.Command) error {
 			slog.Error("failed to process frame: " + err.Error())
 			frame.Close()
 
-			continue
+			return err
 		}
 
 		if mcpEnabled {


### PR DESCRIPTION
This PR fixes the behavior when processing frames to exit on a fatal processor error instead of just continuing.