### PR TITLE
refs: increase the size of the possible indexes for references

### DIFF
--- a/runtime/refs.go
+++ b/runtime/refs.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 )
 
-const maxIndex = 1048560
+const maxIndex = 404856732
 
 // MapRefs is a [Refs] implementation powered by a map protected by a mutex.
 // Indexes are generated randomly and checked for collisions.


### PR DESCRIPTION
This PR increases the max size of the possible indexes for references since a very large number of operations can start to result in collisions.