### PR TITLE
fix: add face-expression processor to list of known processors

### DIFF
--- a/guest/processors.go
+++ b/guest/processors.go
@@ -41,6 +41,11 @@ var knownProcessors = map[string]ProcessorFile{
 		Filename: "captions.wasm",
 		URL:      "https://github.com/wasmvision/wasmvision/raw/refs/heads/main/processors/captions.wasm",
 	},
+	"face-expression": {
+		Alias:    "face-expression",
+		Filename: "face-expression.wasm",
+		URL:      "https://github.com/wasmvision/wasmvision/raw/refs/heads/main/processors/face-expression.wasm",
+	},
 	"faceblur": {
 		Alias:    "faceblur",
 		Filename: "faceblur.wasm",


### PR DESCRIPTION
This PR adds the `face-expression.wasm` processor to the list of known processors, as it was omitted in error when the processor itself was added.