### PR TITLE
fix: correctly pass datastorage param

### DIFF
--- a/cmd/wasmvision/run.go
+++ b/cmd/wasmvision/run.go
@@ -52,6 +52,7 @@ func run(ctx context.Context, cmd *cli.Command) error {
 		ProcessorsDir: processorsDir,
 		ModelsDir:     modelsDir,
 		Settings:      config,
+		Datastorage:   datastorage,
 		EnableCUDA:    enableCUDA,
 	})
 	if err != nil {

--- a/cmd/wasmvision/run.go
+++ b/cmd/wasmvision/run.go
@@ -151,7 +151,7 @@ func run(ctx context.Context, cmd *cli.Command) error {
 		r.Refs.Set(frame.ID.Unwrap(), frame)
 
 		i++
-		slog.Info(fmt.Sprintf("Read frame %d", i))
+		slog.Debug(fmt.Sprintf("Read frame %d", i))
 
 		if mcpEnabled {
 			if err := mcpServer.PublishInput(frame); err != nil {

--- a/cv/context.go
+++ b/cv/context.go
@@ -1,6 +1,8 @@
 package cv
 
 import (
+	"log/slog"
+
 	"github.com/wasmvision/wasmvision/config"
 	"github.com/wasmvision/wasmvision/datastore"
 	"github.com/wasmvision/wasmvision/datastore/storage"
@@ -21,15 +23,19 @@ func NewContext(modelsDir string, conf *config.Store, datastorage string, enable
 	var store datastore.DataStorage
 	switch datastorage {
 	case "memory":
+		slog.Info("Using memory datastorage")
 		store = storage.NewMemStorage[string]()
 
 	case "boltdb":
+		slog.Info("Using BoltDB datastorage")
 		store = storage.NewBoltDBStorage()
 
 	case "redis":
+		slog.Info("Using Redis datastorage")
 		store = storage.NewRedisStorage()
 
 	default:
+		slog.Info("Using default datastorage (memory)")
 		store = storage.NewMemStorage[string]()
 	}
 


### PR DESCRIPTION
This PR fixes an issue that choosing datastorage via param was not having any effect. the solution is to correctly pass datastorage param to the runtime.

There is an additional commit in this PR to also slightly improve logging of frame capture and datastorage selected.