### PR TITLE
fix: correct handling of MCP server image requests to avoid races

### DIFF
--- a/cmd/wasmvision/run.go
+++ b/cmd/wasmvision/run.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/urfave/cli/v3"
 	"github.com/wasmvision/wasmvision/capture"
+	"github.com/wasmvision/wasmvision/cv"
 	"github.com/wasmvision/wasmvision/engine"
 	"github.com/wasmvision/wasmvision/runtime"
 )
@@ -154,7 +155,7 @@ func run(ctx context.Context, cmd *cli.Command) error {
 		slog.Debug(fmt.Sprintf("Read frame %d", i))
 
 		if mcpEnabled {
-			if err := mcpServer.PublishInput(frame); err != nil {
+			if err := mcpServer.PublishInput(cv.NewFrame(frame.Image.Clone())); err != nil {
 				slog.Error("failed to publish input frame to MCP server:" + err.Error())
 			}
 		}
@@ -168,7 +169,7 @@ func run(ctx context.Context, cmd *cli.Command) error {
 		}
 
 		if mcpEnabled {
-			if err := mcpServer.PublishOutput(outframe); err != nil {
+			if err := mcpServer.PublishOutput(cv.NewFrame(outframe.Image.Clone())); err != nil {
 				slog.Error("failed to publish output frame to MCP server:" + err.Error())
 			}
 		}

--- a/engine/mcp_test.go
+++ b/engine/mcp_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/wasmvision/wasmvision/cv"
 	"gocv.io/x/gocv"
@@ -15,6 +16,10 @@ func TestMCPServer(t *testing.T) {
 		port := ":8081"
 
 		s := NewMCPServer(port)
+		defer func() {
+			s.Close()
+			time.Sleep(500 * time.Millisecond)
+		}()
 
 		if s.Port != port {
 			t.Errorf("unexpected port: %s", s.Port)
@@ -33,7 +38,11 @@ func TestMCPServerStart(t *testing.T) {
 		s := NewMCPServer(port)
 
 		s.Start()
-		defer s.Close()
+		defer func() {
+			s.Close()
+			time.Sleep(500 * time.Millisecond)
+		}()
+
 		img := gocv.IMRead("../images/wasmvision-logo.png", gocv.IMReadColor)
 		frm := cv.NewFrame(img)
 		if err := s.PublishOutput(frm); err != nil {
@@ -48,7 +57,10 @@ func TestMCPServerEndpoint(t *testing.T) {
 
 		s := NewMCPServer(port)
 		s.Start()
-		defer s.Close()
+		defer func() {
+			s.Close()
+			time.Sleep(500 * time.Millisecond)
+		}()
 
 		sseResp, err := http.Get(fmt.Sprintf("%s/sse", port))
 		if err != nil {


### PR DESCRIPTION
This PR is to correct the handling of MCP server image requests to avoid races. It also avoids an extra copy that was happening, but not at the correct time to avoid the crash.

Fixes #99 