### PR TITLE
feature: support image file output

### DIFF
--- a/cmd/wasmvision/run.go
+++ b/cmd/wasmvision/run.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/urfave/cli/v3"
@@ -16,7 +17,7 @@ import (
 
 var (
 	mjpegstream *engine.MJPEGStream
-	videoWriter *engine.VideoWriter
+	fileWriter  engine.FileWriter
 )
 
 func run(ctx context.Context, cmd *cli.Command) error {
@@ -102,13 +103,23 @@ func run(ctx context.Context, cmd *cli.Command) error {
 		if destination == "" {
 			return fmt.Errorf("you must profile a file destination for output=file")
 		}
-		videoWriter = engine.NewVideoWriter(r.Refs, destination)
 
-		if err := videoWriter.Start(device); err != nil {
-			return fmt.Errorf("failed starting video writer: %w", err)
+		// video or image writer
+		switch filepath.Ext(destination) {
+		case ".jpg", ".png":
+			// image writer
+			fileWriter = engine.NewImageWriter(r.Refs, destination)
+		default:
+			// video writer
+			fileWriter = engine.NewVideoWriter(r.Refs, destination)
 		}
 
-		defer videoWriter.Close()
+		if err := fileWriter.Start(device); err != nil {
+			return fmt.Errorf("failed starting file writer: %w", err)
+		}
+
+		defer fileWriter.Close()
+
 	case "none":
 		// do nothing
 	default:
@@ -185,7 +196,7 @@ func run(ctx context.Context, cmd *cli.Command) error {
 		case "mjpeg":
 			mjpegstream.Publish(outframe)
 		case "file":
-			videoWriter.Write(outframe)
+			fileWriter.Write(outframe)
 		case "none":
 			outframe.Close()
 		}

--- a/engine/filewriter.go
+++ b/engine/filewriter.go
@@ -1,0 +1,12 @@
+package engine
+
+import (
+	"github.com/wasmvision/wasmvision/capture"
+	"github.com/wasmvision/wasmvision/cv"
+)
+
+type FileWriter interface {
+	Close()
+	Write(*cv.Frame) error
+	Start(capture.Capture) error
+}

--- a/engine/imagewriter.go
+++ b/engine/imagewriter.go
@@ -1,0 +1,59 @@
+package engine
+
+import (
+	"log/slog"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/wasmvision/wasmvision/capture"
+	"github.com/wasmvision/wasmvision/cv"
+	"github.com/wasmvision/wasmvision/runtime"
+	"gocv.io/x/gocv"
+)
+
+// ImageWriter represents a file writer used for saving image frames
+type ImageWriter struct {
+	Filename string
+	refs     *runtime.MapRefs
+	frames   chan *cv.Frame
+}
+
+func NewImageWriter(refs *runtime.MapRefs, dest string) *ImageWriter {
+	return &ImageWriter{
+		Filename: dest,
+		refs:     refs,
+		frames:   make(chan *cv.Frame, framebufferSize),
+	}
+}
+
+func (iw *ImageWriter) Close() {
+	time.Sleep(500 * time.Millisecond)
+
+	close(iw.frames)
+}
+
+func (iw *ImageWriter) Write(img *cv.Frame) error {
+	iw.frames <- img
+	return nil
+}
+
+func (iw *ImageWriter) Start(source capture.Capture) error {
+	go iw.writeFrames()
+
+	return nil
+}
+
+func (iw *ImageWriter) writeFrames() {
+	for frame := range iw.frames {
+		filename := strings.Replace(iw.Filename, "{id}", strconv.Itoa(int(frame.ID.Unwrap())), -1)
+		if !gocv.IMWrite(filename, frame.Image) {
+			slog.Error("error writing frame", "id", strconv.Itoa(int(frame.ID.Unwrap())))
+		}
+
+		slog.Info("wrote frame", "id", strconv.Itoa(int(frame.ID.Unwrap())), "to", filename)
+
+		frame.Close()
+		iw.refs.Drop(frame.ID.Unwrap())
+	}
+}

--- a/engine/imagewriter_test.go
+++ b/engine/imagewriter_test.go
@@ -1,0 +1,48 @@
+package engine
+
+import (
+	"testing"
+
+	"github.com/wasmvision/wasmvision/cv"
+	"github.com/wasmvision/wasmvision/runtime"
+	"gocv.io/x/gocv"
+)
+
+func TestImageWriter(t *testing.T) {
+	t.Run("new image writer", func(t *testing.T) {
+		refs := runtime.NewMapRefs()
+		dest := "output.jpg"
+
+		vw := NewImageWriter(refs, dest)
+
+		if vw.Filename != dest {
+			t.Errorf("unexpected filename: %s", vw.Filename)
+		}
+
+		if vw.refs != refs {
+			t.Errorf("unexpected refs")
+		}
+
+		if vw.frames == nil {
+			t.Errorf("unexpected nil frames")
+		}
+	})
+
+	t.Run("write image frame", func(t *testing.T) {
+		refs := runtime.NewMapRefs()
+
+		tmp := t.TempDir()
+		dest := tmp + "/output.jpg"
+
+		vw := NewImageWriter(refs, dest)
+
+		defer vw.Close()
+
+		img := gocv.IMRead("../images/wasmvision-logo.png", gocv.IMReadColor)
+		frm := cv.NewFrame(img)
+
+		if err := vw.Write(frm); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+}


### PR DESCRIPTION
This PR adds support for JPG and PNG image file output.

Output to a single file:

```
--output=file --destination=image.png
```

Output to a sequence of files:

```
--output=file --destination=images{id}.png
```